### PR TITLE
Improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "[cpp]": {
+        "editor.defaultFormatter": "xaver.clang-format"
+    },
+    "[c]": {
+        "editor.defaultFormatter": "xaver.clang-format"
+    },
+    "editor.formatOnSave": true,
+    "files.associations": {
+        "expected": "cpp"
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ endif ()
 # ============================================================================
 set(SRC_FILES
     src/fwfinder.cpp
+    src/fwbuilder.cpp
     src/fwfinder_linux.cpp
     src/fwfinder_mac.cpp
     src/fwfinder_windows.cpp

--- a/README.md
+++ b/README.md
@@ -144,26 +144,6 @@ enum class USBDeviceType {
 };
 ```
 
-#### Data Structures
-
-```cpp
-struct USBDevice {
-    USBDeviceType kind;
-    uint16_t vid, pid;
-    std::string name, serial;
-    uint32_t location;
-    std::optional<std::string> port;           // For serial devices
-    std::optional<std::vector<std::string>> paths; // For mass storage
-};
-
-struct FreeWiliDevice {
-    std::string name, serial;
-    std::vector<USBDevice> usbDevices;
-
-    auto getUSBDevices(USBDeviceType type) const -> std::vector<USBDevice>;
-};
-```
-
 ### C API (`cfwfinder.h`)
 
 #### Core Functions

--- a/bindings/python/src/pyfwfinder.cpp
+++ b/bindings/python/src/pyfwfinder.cpp
@@ -38,8 +38,8 @@ NB_MODULE(pyfwfinder, m) {
     nb::enum_<Fw::DeviceType>(m, "DeviceType")
         .value("Unknown", Fw::DeviceType::Unknown)
         .value("FreeWili", Fw::DeviceType::FreeWili)
-        .value("DefCon2024Badge", Fw::DeviceType::DefCon2024Badge)
-        .value("DefCon2025FwBadge", Fw::DeviceType::DefCon2025FwBadge)
+        .value("DEFCON2024Badge", Fw::DeviceType::DEFCON2024Badge)
+        .value("DEFCON2025FwBadge", Fw::DeviceType::DEFCON2025FwBadge)
         .value("Winky", Fw::DeviceType::Winky)
         .value("UF2", Fw::DeviceType::UF2)
         .export_values();
@@ -92,10 +92,8 @@ NB_MODULE(pyfwfinder, m) {
         )
         .def(
             "get_usb_devices",
-            [](const Fw::FreeWiliDevice& self,
-               const std::vector<Fw::USBDeviceType>& usbDeviceTypes) {
-                return self.getUSBDevices(usbDeviceTypes);
-            }
+            [](const Fw::FreeWiliDevice& self, const std::vector<Fw::USBDeviceType>& usbDeviceTypes
+            ) { return self.getUSBDevices(usbDeviceTypes); }
         )
         .def(
             "get_main_usb_device",

--- a/bindings/python/src/pyfwfinder.cpp
+++ b/bindings/python/src/pyfwfinder.cpp
@@ -52,6 +52,10 @@ NB_MODULE(pyfwfinder, m) {
                 return Fw::getUSBDeviceTypeName(self.kind) + " " + self.name + " " + self.serial;
             }
         )
+        .def(
+            "__eq__",
+            [](const Fw::USBDevice& self, const Fw::USBDevice& other) { return self == other; }
+        )
         .def_ro("kind", &Fw::USBDevice::kind)
         .def_ro("vid", &Fw::USBDevice::vid)
         .def_ro("pid", &Fw::USBDevice::pid)
@@ -63,16 +67,83 @@ NB_MODULE(pyfwfinder, m) {
         .def_ro("_raw", &Fw::USBDevice::_raw);
 
     nb::class_<Fw::FreeWiliDevice>(m, "FreeWiliDevice")
-        .def(nb::init<>())
         .def(
             "__str__",
             [](const Fw::FreeWiliDevice& self) { return self.name + " " + self.serial; }
         )
+        .def(
+            "__eq__",
+            [](const Fw::FreeWiliDevice& self, const Fw::FreeWiliDevice& other) {
+                return self == other;
+            }
+        )
         .def_ro("device_type", &Fw::FreeWiliDevice::deviceType)
         .def_ro("name", &Fw::FreeWiliDevice::name)
         .def_ro("serial", &Fw::FreeWiliDevice::serial)
+        .def_ro("unique_id", &Fw::FreeWiliDevice::uniqueID)
+        .def_ro("standalone", &Fw::FreeWiliDevice::standalone)
         .def_ro("usb_devices", &Fw::FreeWiliDevice::usbDevices)
-        .def("get_usb_devices", &Fw::FreeWiliDevice::getUSBDevices);
+        .def("get_usb_devices", [](const Fw::FreeWiliDevice& self) { return self.getUSBDevices(); })
+        .def(
+            "get_usb_devices",
+            [](const Fw::FreeWiliDevice& self, Fw::USBDeviceType usbDeviceType) {
+                return self.getUSBDevices(usbDeviceType);
+            }
+        )
+        .def(
+            "get_usb_devices",
+            [](const Fw::FreeWiliDevice& self,
+               const std::vector<Fw::USBDeviceType>& usbDeviceTypes) {
+                return self.getUSBDevices(usbDeviceTypes);
+            }
+        )
+        .def(
+            "get_main_usb_device",
+            [](const Fw::FreeWiliDevice& self) {
+                auto result = self.getMainUSBDevice();
+                if (result.has_value()) {
+                    return result.value();
+                } else {
+                    PyErr_SetString(PyExc_RuntimeError, result.error().c_str());
+                    throw nb::python_error();
+                }
+            }
+        )
+        .def(
+            "get_display_usb_device",
+            [](const Fw::FreeWiliDevice& self) {
+                auto result = self.getDisplayUSBDevice();
+                if (result.has_value()) {
+                    return result.value();
+                } else {
+                    PyErr_SetString(PyExc_RuntimeError, result.error().c_str());
+                    throw nb::python_error();
+                }
+            }
+        )
+        .def(
+            "get_fpga_usb_device",
+            [](const Fw::FreeWiliDevice& self) {
+                auto result = self.getFPGAUSBDevice();
+                if (result.has_value()) {
+                    return result.value();
+                } else {
+                    PyErr_SetString(PyExc_RuntimeError, result.error().c_str());
+                    throw nb::python_error();
+                }
+            }
+        )
+        .def("get_hub_usb_device", [](const Fw::FreeWiliDevice& self) {
+            auto result = self.getHubUSBDevice();
+            if (result.has_value()) {
+                return result.value();
+            } else {
+                PyErr_SetString(PyExc_RuntimeError, result.error().c_str());
+                throw nb::python_error();
+            }
+        });
 
     m.def("find_all", &find_all);
+    m.def("get_device_type_name", &Fw::getDeviceTypeName);
+    m.def("get_usb_device_type_name", &Fw::getUSBDeviceTypeName);
 }

--- a/bindings/python/tests/test_basic.py
+++ b/bindings/python/tests/test_basic.py
@@ -32,15 +32,15 @@ def test_usbdevice() -> None:
 def test_devicetype() -> None:
     assert hasattr(pyfwfinder, "DeviceType")
     assert hasattr(pyfwfinder.DeviceType, "FreeWili")
-    assert hasattr(pyfwfinder.DeviceType, "DefCon2024Badge")
-    assert hasattr(pyfwfinder.DeviceType, "DefCon2025FwBadge")
+    assert hasattr(pyfwfinder.DeviceType, "DEFCON2024Badge")
+    assert hasattr(pyfwfinder.DeviceType, "DEFCON2025FwBadge")
     assert hasattr(pyfwfinder.DeviceType, "Winky")
     assert hasattr(pyfwfinder.DeviceType, "UF2")
 
     assert pyfwfinder.DeviceType.Unknown.value == 0
     assert pyfwfinder.DeviceType.FreeWili.value == 1
-    assert pyfwfinder.DeviceType.DefCon2024Badge.value == 2
-    assert pyfwfinder.DeviceType.DefCon2025FwBadge.value == 3
+    assert pyfwfinder.DeviceType.DEFCON2024Badge.value == 2
+    assert pyfwfinder.DeviceType.DEFCON2025FwBadge.value == 3
     assert pyfwfinder.DeviceType.UF2.value == 4
     assert pyfwfinder.DeviceType.Winky.value == 5
 

--- a/c_api/CMakeLists.txt
+++ b/c_api/CMakeLists.txt
@@ -105,4 +105,37 @@ if (FW_FINDER_BUILD_TESTS AND FW_BUILD_STATIC)
         COMMAND "${C_API_PROJECT_NAME}_test"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+
+    # Fixed string copy unit tests
+    add_executable(
+        "test_fixed_string_copy"
+        test/test_fixed_string_copy.cpp
+    )
+
+    target_include_directories(
+        "test_fixed_string_copy"
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include
+    )
+
+    target_link_libraries(
+        "test_fixed_string_copy"
+        PRIVATE
+            GTest::gtest_main
+    )
+
+    # Define that we're using static linking for the test
+    target_compile_definitions(
+        "test_fixed_string_copy"
+        PRIVATE
+            CFW_FINDER_BUILD_STATIC
+    )
+
+    # Register the fixed string copy test with CTest
+    add_test(
+        NAME "fixed_string_copy_test"
+        COMMAND "test_fixed_string_copy"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
 endif ()

--- a/c_api/include/cfwfinder.h
+++ b/c_api/include/cfwfinder.h
@@ -107,6 +107,17 @@ typedef enum _fw_inttype_t {
 } _fw_inttype_t;
 typedef uint32_t fw_inttype_t;
 
+typedef enum _fw_usbdevice_set_t {
+    fw_usbdevice_iter_main,
+    fw_usbdevice_iter_display,
+    fw_usbdevice_iter_fpga,
+    fw_usbdevice_iter_hub,
+
+    // Keep this at the end
+    fw_usbdevice_iter__maxvalue
+} _fw_usbdevice_iter_set_t;
+typedef uint32_t fw_usbdevice_iter_set_t;
+
 /**
  * @brief Opaque type for a C++ FreeWiliDevice.
  *
@@ -206,6 +217,46 @@ CFW_FINDER_API fw_error_t
 fw_device_get_type(fw_freewili_device_t* device, fw_devicetype_t* device_type);
 
 /**
+ * @brief Retrieves the name of the device type.
+ *
+ * This function retrieves the type of device being enumerated.
+ * The type is returned as a fw_devicetype_t value.
+ *
+ * @param device_type Pointer to the fw_devicetype_t from which to retrieve the name of the device type.
+ * @param name[out] Pointer to a buffer where the name of the device type will be stored.
+ * @param name_size[in,out] Pointer to a uint32_t that will be updated with the size of the name buffer.
+ *
+ * @return fw_error_success on success, or an error code on failure.
+ */
+CFW_FINDER_API fw_error_t
+fw_device_get_type_name(fw_devicetype_t device_type, char* const name, uint32_t* name_size);
+
+/**
+ * @brief Determine if the device is standalone.
+ *
+ * This function checks if the specified FreeWiLi device is standalone (not part of a hub).
+ *
+ * @param device        Pointer to the fw_freewili_device_t to check.
+ * @param is_standalone Pointer to a boolean that will be set to true if the device is standalone, false otherwise.
+ *
+ * @return fw_error_success if the operation was successful, fw_error_invalid_argument if the device or is_standalone is NULL.
+ */
+CFW_FINDER_API fw_error_t
+fw_device_is_standalone(fw_freewili_device_t* device, bool* is_standalone);
+
+/**
+ * @brief Get the unique ID of the device.
+ *
+ * This function retrieves the unique ID of the specified FreeWiLi device.
+ *
+ * @param device Pointer to the fw_freewili_device_t to check.
+ * @param unique_id Pointer to a uint64_t that will be set to the unique ID of the device.
+ *
+ * @return fw_error_success if the operation was successful, fw_error_invalid_argument if the device or unique_id is NULL.
+ */
+CFW_FINDER_API fw_error_t fw_device_unique_id(fw_freewili_device_t* device, uint64_t* unique_id);
+
+/**
     * @brief Begins the USB device enumeration for a FreeWiLi device.
     *
     * This function initializes the USB device enumeration process for the specified FreeWiLi device.
@@ -241,6 +292,30 @@ CFW_FINDER_API fw_error_t fw_usb_device_begin(fw_freewili_device_t* device);
 CFW_FINDER_API fw_error_t fw_usb_device_next(fw_freewili_device_t* device);
 
 /**
+    * @brief Retrieves the specified USB device from a FreeWiLi device.
+    *
+    * @param device Pointer to the fw_freewili_device_t for which to select the USB device.
+    * @param iter_set The USB device iterator set to use.
+    * @param error_message Pointer to a buffer where the error message will be stored.
+    * @param error_message_size Pointer to a uint32_t that will be updated with the size of the error message.
+    *
+    * @return fw_error_success on success, or an error code on failure. fw_error_no_more_devices if there are no more USB devices to enumerate.
+    *
+    * @note This function doesn't need fw_usb_device_begin to be called first. This interrupts the iterator state, 
+    *       fw_usb_device_begin should be called again if fw_usb_device_next needs to be used.
+    *       It will return the Main USB device or an error if there are no more devices.
+    *
+    * @see fw_usb_device_get_str
+    * @see fw_usb_device_get_int
+ */
+CFW_FINDER_API fw_error_t fw_usb_device_set(
+    fw_freewili_device_t* device,
+    fw_usbdevice_iter_set_t iter_set,
+    char* const error_message,
+    uint32_t* error_message_size
+);
+
+/**
  * @brief Provides the count of USB devices found.
  *
  * @param device Pointer to the fw_freewili_device_t from which to retrieve the next USB device.
@@ -263,6 +338,24 @@ CFW_FINDER_API fw_error_t fw_usb_device_count(fw_freewili_device_t* device, uint
  */
 CFW_FINDER_API fw_error_t
 fw_usb_device_get_type(fw_freewili_device_t* device, fw_usbdevicetype_t* usb_device_type);
+
+/**
+ * @brief Retrieves the name of the USB device type.
+ *
+ * This function retrieves the type of USB device being enumerated.
+ * The type is returned as a fw_usbdevicetype_t value.
+ *
+ * @param usb_device_type Pointer to the fw_usbdevicetype_t from which to retrieve the name of the USB device type.
+ * @param name[out] Pointer to a buffer where the name of the USB device type will be stored.
+ * @param name_size[in,out] Pointer to a uint32_t that will be updated with the size of the name buffer.
+ *
+ * @return fw_error_success on success, or an error code on failure.
+ */
+CFW_FINDER_API fw_error_t fw_usb_device_get_type_name(
+    fw_usbdevicetype_t usb_device_type,
+    char* const name,
+    uint32_t* name_size
+);
 
 /**
  * @brief Retrieves a string value from a USB device.

--- a/c_api/include/cfwfinder_internal.hpp
+++ b/c_api/include/cfwfinder_internal.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <optional>
+#include <concepts>
+#include <cstring>
+
+/**
+ * @brief Template function for safely copying strings to fixed-size buffers
+ *
+ * This function copies a string to a destination buffer with size tracking,
+ * ensuring null termination and preventing buffer overflows.
+ *
+ * @tparam size_type An unsigned integral type for size parameters
+ * @param dest Destination buffer (must not be nullptr)
+ * @param dest_size Pointer to buffer size (input: max size, output: actual size including null terminator)
+ * @param src Source string to copy
+ * @return Optional containing the number of characters copied (excluding null terminator), or nullopt on error
+ */
+template<typename size_type>
+    requires std::unsigned_integral<size_type>
+auto fixedStringCopy(char* const dest, size_type* dest_size, std::string src)
+    -> std::optional<size_type> {
+    if (dest == nullptr || dest_size == nullptr || *dest_size == 0) {
+        return std::nullopt;
+    }
+
+    // Clear the destination buffer for safety
+    memset(dest, 0, *dest_size);
+    size_type size = src.copy(dest, *dest_size - 1);
+    dest[size] = '\0'; // Null-terminate the string
+    *dest_size = size + 1; // Update the size to include the null terminator
+    return size;
+}

--- a/c_api/src/cfwfinder.cpp
+++ b/c_api/src/cfwfinder.cpp
@@ -153,6 +153,70 @@ fw_device_get_type(fw_freewili_device_t* device, fw_devicetype_t* device_type) {
     return fw_error_success;
 }
 
+CFW_FINDER_API fw_error_t
+fw_device_get_type_name(fw_devicetype_t device_type, char* const name, uint32_t* name_size) {
+    if (name == nullptr || name_size == nullptr) {
+        return fw_error_invalid_parameter;
+    }
+
+    std::string type_name;
+    switch (device_type) {
+        case fw_devicetype_unknown:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::Unknown);
+            break;
+        case fw_devicetype_freewili:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::FreeWili);
+            break;
+        case fw_devicetype_defcon2024badge:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge);
+            break;
+        case fw_devicetype_defcon2025fwbadge:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DefCon2025FwBadge);
+            break;
+        case fw_devicetype_uf2:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::UF2);
+            break;
+        case fw_devicetype_winky:
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::Winky);
+            break;
+        default:
+            type_name = std::string("Unknown Device Type");
+    }
+
+    auto size = type_name.copy(name, *name_size - 1);
+    name[*name_size - 1] = '\0'; // Null-terminate the string
+    *name_size = size + 1; // Update the size to include the null terminator
+
+    return fw_error_success;
+}
+
+CFW_FINDER_API fw_error_t
+fw_device_is_standalone(fw_freewili_device_t* device, bool* is_standalone) {
+    if (device == nullptr || is_standalone == nullptr) {
+        return fw_error_invalid_parameter;
+    }
+
+    if (!fw_device_is_valid(device)) {
+        return fw_error_invalid_device;
+    }
+
+    *is_standalone = device->device.standalone;
+    return fw_error_success;
+}
+
+CFW_FINDER_API fw_error_t fw_device_unique_id(fw_freewili_device_t* device, uint64_t* unique_id) {
+    if (device == nullptr || unique_id == nullptr) {
+        return fw_error_invalid_parameter;
+    }
+
+    if (!fw_device_is_valid(device)) {
+        return fw_error_invalid_device;
+    }
+
+    *unique_id = device->device.uniqueID;
+    return fw_error_success;
+}
+
 CFW_FINDER_API fw_error_t fw_usb_device_begin(fw_freewili_device_t* device) {
     if (device == nullptr) {
         return fw_error_invalid_parameter;
@@ -181,7 +245,62 @@ CFW_FINDER_API fw_error_t fw_usb_device_next(fw_freewili_device_t* device) {
     }
 
     ++device->usbDevicesIter; // Move to the next USB device
-    return fw_error_success;
+    if (device->usbDevicesIter == device->device.usbDevices.end()) {
+        return fw_error_no_more_devices; // No more USB devices to enumerate
+    } else {
+        return fw_error_success;
+    }
+}
+
+CFW_FINDER_API fw_error_t fw_usb_device_set(
+    fw_freewili_device_t* device,
+    fw_usbdevice_iter_set_t iter_set,
+    char* const error_message,
+    uint32_t* error_message_size
+) {
+    if (device == nullptr || error_message == nullptr || error_message_size == nullptr) {
+        return fw_error_invalid_parameter;
+    }
+
+    if (!fw_device_is_valid(device)) {
+        return fw_error_invalid_device;
+    }
+
+    auto usb_device = std::expected<USBDevice, std::string> {};
+
+    if (iter_set == fw_usbdevice_iter_main) {
+        usb_device = device->device.getMainUSBDevice();
+    } else if (iter_set == fw_usbdevice_iter_display) {
+        usb_device = device->device.getDisplayUSBDevice();
+    } else if (iter_set == fw_usbdevice_iter_fpga) {
+        usb_device = device->device.getFPGAUSBDevice();
+    } else if (iter_set == fw_usbdevice_iter_hub) {
+        usb_device = device->device.getHubUSBDevice();
+    } else {
+        usb_device = std::unexpected("Invalid USB device iterator set");
+    }
+
+    if (usb_device.has_value()) {
+        device->usbDevicesIter = std::find_if(
+            device->device.usbDevices.begin(),
+            device->device.usbDevices.end(),
+            [&](USBDevice& d) { return d == usb_device.value(); }
+        );
+        if (device->usbDevicesIter == device->device.usbDevices.end()) {
+            auto size = std::string("fw_usb_device_set() internal error")
+                            .copy(error_message, *error_message_size - 1);
+            error_message[*error_message_size - 1] = '\0'; // Null-terminate the string
+            *error_message_size = size + 1; // Update the size to include the null terminator
+            return fw_error_internal_error;
+        }
+        return fw_error_success;
+    } else {
+        // Unable to get Main USB device
+        auto size = usb_device.error().copy(error_message, *error_message_size - 1);
+        error_message[*error_message_size - 1] = '\0'; // Null-terminate the string
+        *error_message_size = size + 1; // Update the size to include the null terminator
+        return fw_error_no_more_devices;
+    }
 }
 
 CFW_FINDER_API fw_error_t fw_usb_device_count(fw_freewili_device_t* device, uint32_t* count) {
@@ -213,6 +332,52 @@ fw_usb_device_get_type(fw_freewili_device_t* device, fw_usbdevicetype_t* usb_dev
 
     const auto& usbDevice = *device->usbDevicesIter;
     *usb_device_type = static_cast<fw_usbdevicetype_t>(usbDevice.kind);
+    return fw_error_success;
+}
+
+CFW_FINDER_API fw_error_t fw_usb_device_get_type_name(
+    fw_usbdevicetype_t usb_device_type,
+    char* const name,
+    uint32_t* name_size
+) {
+    if (name == nullptr || name_size == nullptr) {
+        return fw_error_invalid_parameter;
+    }
+
+    std::string type_name;
+    switch (usb_device_type) {
+        case fw_usbdevicetype_hub:
+            type_name = getUSBDeviceTypeName(USBDeviceType::Hub);
+            break;
+        case fw_usbdevicetype_serial:
+            type_name = getUSBDeviceTypeName(USBDeviceType::Serial);
+            break;
+        case fw_usbdevicetype_serialmain:
+            type_name = getUSBDeviceTypeName(USBDeviceType::SerialMain);
+            break;
+        case fw_usbdevicetype_serialdisplay:
+            type_name = getUSBDeviceTypeName(USBDeviceType::SerialDisplay);
+            break;
+        case fw_usbdevicetype_massstorage:
+            type_name = getUSBDeviceTypeName(USBDeviceType::MassStorage);
+            break;
+        case fw_usbdevicetype_esp32:
+            type_name = getUSBDeviceTypeName(USBDeviceType::ESP32);
+            break;
+        case fw_usbdevicetype_ftdi:
+            type_name = getUSBDeviceTypeName(USBDeviceType::FTDI);
+            break;
+        case fw_usbdevicetype_other:
+            type_name = getUSBDeviceTypeName(USBDeviceType::Other);
+            break;
+        default:
+            type_name = std::string("Unknown USB Device Type");
+    }
+
+    auto size = type_name.copy(name, *name_size - 1);
+    name[*name_size - 1] = '\0'; // Null-terminate the string
+    *name_size = size + 1; // Update the size to include the null terminator
+
     return fw_error_success;
 }
 
@@ -252,8 +417,7 @@ CFW_FINDER_API fw_error_t fw_usb_device_get_str(
         case fw_stringtype_serial:
             return copy_value(usbDevice.serial);
             break;
-        case fw_stringtype_path:
-        {
+        case fw_stringtype_path: {
             if (!usbDevice.paths.has_value() || usbDevice.paths.value().empty()) {
                 return fw_error_none; // No path available for this USB device
             }

--- a/c_api/src/cfwfinder.cpp
+++ b/c_api/src/cfwfinder.cpp
@@ -172,10 +172,10 @@ fw_device_get_type_name(fw_devicetype_t device_type, char* const name, uint32_t*
             type_name = Fw::getDeviceTypeName(Fw::DeviceType::FreeWili);
             break;
         case fw_devicetype_defcon2024badge:
-            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge);
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DEFCON2024Badge);
             break;
         case fw_devicetype_defcon2025fwbadge:
-            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DefCon2025FwBadge);
+            type_name = Fw::getDeviceTypeName(Fw::DeviceType::DEFCON2025FwBadge);
             break;
         case fw_devicetype_uf2:
             type_name = Fw::getDeviceTypeName(Fw::DeviceType::UF2);

--- a/c_api/test/test_cfwfinder.cpp
+++ b/c_api/test/test_cfwfinder.cpp
@@ -223,6 +223,9 @@ TEST(CFwFinderCAPI, UsbDeviceEnumeration_IfDeviceFound) {
 
             // Move to the next USB device
             err = fw_usb_device_next(devices[i]);
+            if (err == fw_error_no_more_devices) {
+                break;
+            }
             ASSERT_EQ(err, fw_error_success);
         }
     }

--- a/c_api/test/test_fixed_string_copy.cpp
+++ b/c_api/test/test_fixed_string_copy.cpp
@@ -1,0 +1,225 @@
+#include <gtest/gtest.h>
+#include <cfwfinder_internal.hpp>
+
+class FixedStringCopyTest: public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Clear buffer before each test
+        memset(buffer, 0xAA, sizeof(buffer)); // Fill with known pattern
+    }
+
+    static constexpr size_t BUFFER_SIZE = 64;
+    char buffer[BUFFER_SIZE];
+};
+
+// Test basic functionality with normal strings
+TEST_F(FixedStringCopyTest, BasicCopy) {
+    std::string source = "Hello World";
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), source.length());
+    EXPECT_STREQ(buffer, "Hello World");
+    EXPECT_EQ(buffer_size, source.length() + 1); // +1 for null terminator
+    EXPECT_EQ(buffer[source.length()], '\0'); // Verify null termination
+}
+
+// Test with empty string
+TEST_F(FixedStringCopyTest, EmptyString) {
+    std::string source = "";
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 0);
+    EXPECT_STREQ(buffer, "");
+    EXPECT_EQ(buffer_size, 1); // Just the null terminator
+    EXPECT_EQ(buffer[0], '\0');
+}
+
+// Test with string that exactly fits buffer
+TEST_F(FixedStringCopyTest, ExactFit) {
+    std::string source(BUFFER_SIZE - 1, 'X'); // Fill buffer exactly (minus null terminator)
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), BUFFER_SIZE - 1);
+    EXPECT_EQ(strlen(buffer), BUFFER_SIZE - 1);
+    EXPECT_EQ(buffer_size, BUFFER_SIZE); // size + null terminator
+    EXPECT_EQ(buffer[BUFFER_SIZE - 1], '\0');
+}
+
+// Test with string longer than buffer (truncation)
+TEST_F(FixedStringCopyTest, StringTooLong) {
+    std::string source(BUFFER_SIZE + 10, 'Y'); // Longer than buffer
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), BUFFER_SIZE - 1); // Truncated length
+    EXPECT_EQ(strlen(buffer), BUFFER_SIZE - 1);
+    EXPECT_EQ(buffer_size, BUFFER_SIZE); // size + null terminator
+    EXPECT_EQ(buffer[BUFFER_SIZE - 1], '\0');
+
+    // Verify all characters before null terminator are 'Y'
+    for (size_t i = 0; i < BUFFER_SIZE - 1; ++i) {
+        EXPECT_EQ(buffer[i], 'Y');
+    }
+}
+
+// Test with very small buffer
+TEST_F(FixedStringCopyTest, SmallBuffer) {
+    std::string source = "Hello";
+    uint32_t buffer_size = 3; // Only room for 2 chars + null terminator
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 2);
+    EXPECT_EQ(strlen(buffer), 2);
+    EXPECT_EQ(buffer_size, 3);
+    EXPECT_STREQ(buffer, "He");
+    EXPECT_EQ(buffer[2], '\0');
+}
+
+// Test with buffer size of 1 (only null terminator)
+TEST_F(FixedStringCopyTest, BufferSizeOne) {
+    std::string source = "Hello";
+    uint32_t buffer_size = 1;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 0);
+    EXPECT_EQ(strlen(buffer), 0);
+    EXPECT_EQ(buffer_size, 1);
+    EXPECT_STREQ(buffer, "");
+    EXPECT_EQ(buffer[0], '\0');
+}
+
+// Test null pointer parameters
+TEST_F(FixedStringCopyTest, NullDestPointer) {
+    std::string source = "Hello";
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy<uint32_t>(nullptr, &buffer_size, source);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FixedStringCopyTest, NullSizePointer) {
+    std::string source = "Hello";
+
+    auto result = fixedStringCopy<uint32_t>(buffer, nullptr, source);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(FixedStringCopyTest, BothNullPointers) {
+    std::string source = "Hello";
+
+    auto result = fixedStringCopy<uint32_t>(nullptr, nullptr, source);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+// Test with different unsigned integer types
+TEST_F(FixedStringCopyTest, DifferentSizeTypes) {
+    std::string source = "Test";
+
+    // Test with uint8_t
+    {
+        uint8_t size8 = 10;
+        auto result = fixedStringCopy(buffer, &size8, source);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value(), 4);
+        EXPECT_EQ(size8, 5);
+    }
+
+    // Test with uint16_t
+    {
+        uint16_t size16 = 10;
+        auto result = fixedStringCopy(buffer, &size16, source);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value(), 4);
+        EXPECT_EQ(size16, 5);
+    }
+
+    // Test with uint64_t
+    {
+        uint64_t size64 = 10;
+        auto result = fixedStringCopy(buffer, &size64, source);
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value(), 4);
+        EXPECT_EQ(size64, 5);
+    }
+}
+
+// Test buffer clearing behavior
+TEST_F(FixedStringCopyTest, BufferClearing) {
+    // Fill buffer with known pattern
+    memset(buffer, 0xFF, BUFFER_SIZE);
+
+    std::string source = "Hi";
+    uint32_t buffer_size = 10;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_STREQ(buffer, "Hi");
+
+    // Verify that bytes after the string are cleared (not 0xFF anymore)
+    for (size_t i = 3; i < 10; ++i) {
+        EXPECT_EQ(buffer[i], 0) << "Buffer not properly cleared at index " << i;
+    }
+}
+
+// Test with string containing null characters
+TEST_F(FixedStringCopyTest, StringWithNullChars) {
+    std::string source = std::string("Hello\0World", 11); // String with embedded null
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), 11);
+    EXPECT_EQ(buffer_size, 12);
+
+    // Verify the embedded null is preserved
+    EXPECT_EQ(buffer[5], '\0');
+    EXPECT_EQ(buffer[11], '\0'); // Final null terminator
+
+    // Verify the content manually since STREQ stops at first null
+    EXPECT_EQ(memcmp(buffer, "Hello\0World\0", 12), 0);
+}
+
+// Test with Unicode/UTF-8 strings
+TEST_F(FixedStringCopyTest, UTF8String) {
+    std::string source = "Hello 世界"; // UTF-8 string
+    uint32_t buffer_size = BUFFER_SIZE;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), source.length());
+    EXPECT_EQ(buffer_size, source.length() + 1);
+    EXPECT_EQ(memcmp(buffer, source.c_str(), source.length()), 0);
+    EXPECT_EQ(buffer[source.length()], '\0');
+}
+
+// Test edge case: buffer size 0 (should return nullopt safely)
+TEST_F(FixedStringCopyTest, BufferSizeZero) {
+    std::string source = "Hello";
+    uint32_t buffer_size = 0;
+
+    auto result = fixedStringCopy(buffer, &buffer_size, source);
+
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(buffer_size, 0); // Should remain unchanged
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,34 @@ if(WIN32)
     )
 endif()
 
+# Port Chain Analysis Example
+add_executable(
+    test_port_chain
+    test_port_chain.cpp
+)
+
+target_include_directories(
+    test_port_chain
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+)
+
+target_link_libraries(
+    test_port_chain
+    PRIVATE
+        ${PROJECT_NAME}
+)
+
+# Copy DLL to the examples directory on Windows
+if(WIN32)
+    add_custom_command(TARGET test_port_chain POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:${PROJECT_NAME}>
+        $<TARGET_FILE_DIR:test_port_chain>
+        COMMENT "Copying fwfinder.dll to examples directory"
+    )
+endif()
+
 # C Example using the C API
 if (FW_BUILD_C_API)
     add_executable(

--- a/examples/basic_usage.cpp
+++ b/examples/basic_usage.cpp
@@ -37,18 +37,26 @@ int main() {
             if (auto main = device.getMainUSBDevice(); main.has_value()) {
                 std::cout << "  Main USB Device: " << main->name << std::endl;
                 std::cout << "    Location: " << main->location << std::endl;
+            } else {
+                std::cout << "  Main USB Device: " << main.error() << std::endl;
             }
             if (auto display = device.getDisplayUSBDevice(); display.has_value()) {
                 std::cout << "  Display USB Device: " << display->name << std::endl;
                 std::cout << "    Location: " << display->location << std::endl;
+            } else {
+                std::cout << "  Display USB Device: " << display.error() << std::endl;
             }
             if (auto fpga = device.getFPGAUSBDevice(); fpga.has_value()) {
                 std::cout << "  FPGA USB Device: " << fpga->name << std::endl;
                 std::cout << "    Location: " << fpga->location << std::endl;
+            } else {
+                std::cout << "  FPGA USB Device: " << fpga.error() << std::endl;
             }
             if (auto hub = device.getHubUSBDevice(); hub.has_value()) {
                 std::cout << "  Hub USB Device: " << hub->name << std::endl;
                 std::cout << "    Location: " << hub->location << std::endl;
+            } else {
+                std::cout << "  Hub USB Device: " << hub.error() << std::endl;
             }
 
             // Show different types of USB devices

--- a/examples/basic_usage.cpp
+++ b/examples/basic_usage.cpp
@@ -31,7 +31,25 @@ int main() {
             std::cout << "Device " << (i + 1) << ": " << device.name << std::endl;
             std::cout << "  Type: " << Fw::getDeviceTypeName(device.deviceType) << std::endl;
             std::cout << "  Serial: " << device.serial << std::endl;
+            std::cout << "  Unique ID: " << device.uniqueID << std::endl;
             std::cout << "  Total USB Devices: " << device.usbDevices.size() << std::endl;
+
+            if (auto main = device.getMainUSBDevice(); main.has_value()) {
+                std::cout << "  Main USB Device: " << main->name << std::endl;
+                std::cout << "    Location: " << main->location << std::endl;
+            }
+            if (auto display = device.getDisplayUSBDevice(); display.has_value()) {
+                std::cout << "  Display USB Device: " << display->name << std::endl;
+                std::cout << "    Location: " << display->location << std::endl;
+            }
+            if (auto fpga = device.getFPGAUSBDevice(); fpga.has_value()) {
+                std::cout << "  FPGA USB Device: " << fpga->name << std::endl;
+                std::cout << "    Location: " << fpga->location << std::endl;
+            }
+            if (auto hub = device.getHubUSBDevice(); hub.has_value()) {
+                std::cout << "  Hub USB Device: " << hub->name << std::endl;
+                std::cout << "    Location: " << hub->location << std::endl;
+            }
 
             // Show different types of USB devices
             std::cout << "  USB Devices:" << std::endl;

--- a/examples/c_api_basic_usage.c
+++ b/examples/c_api_basic_usage.c
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #include <string.h>
 
+fw_error_t print_usb_device(fw_freewili_device_t* device);
+
 int main(void) {
     printf("FreeWili Device Finder C API Example\n");
     printf("====================================\n\n");
@@ -42,6 +44,8 @@ int main(void) {
         char name[128] = { 0 };
         char serial[128] = { 0 };
         char type[128] = { 0 };
+        bool is_standalone = false;
+        uint64_t unique_id = 0;
 
         // Get device name and serial
         err = fw_device_get_str(devices[i], fw_stringtype_name, name, sizeof(name));
@@ -62,16 +66,23 @@ int main(void) {
             continue;
         }
 
+        err = fw_device_is_standalone(devices[i], &is_standalone);
+        if (err != fw_error_success) {
+            printf("Device %u: Failed to check if device is standalone\n", i + 1);
+            continue;
+        }
+
+        err = fw_device_unique_id(devices[i], &unique_id);
+        if (err != fw_error_success) {
+            printf("Device %u: Failed to get unique ID\n", i + 1);
+            continue;
+        }
+
         printf("Device %u: %s\n", i + 1, name);
         printf("  Serial: %s\n", serial);
         printf("  Type: %s\n", type);
-
-        // Begin USB device enumeration
-        err = fw_usb_device_begin(devices[i]);
-        if (err != fw_error_success) {
-            printf("  Failed to begin USB device enumeration\n");
-            continue;
-        }
+        printf("  Standalone: %s\n", is_standalone ? "Yes" : "No");
+        printf("  Unique ID: %lu\n", unique_id);
 
         // Get USB device count
         uint32_t usb_count = 0;
@@ -81,86 +92,75 @@ int main(void) {
             continue;
         }
 
+        err = fw_usb_device_set(
+            devices[i],
+            fw_usbdevice_iter_main,
+            error_message,
+            &error_message_size
+        );
+        if (err != fw_error_success) {
+            printf("  Failed to set USB device iterator: %s\n", error_message);
+        } else {
+            printf("  Main: ");
+            print_usb_device(devices[i]);
+        }
+
+        err = fw_usb_device_set(
+            devices[i],
+            fw_usbdevice_iter_display,
+            error_message,
+            &error_message_size
+        );
+        if (err != fw_error_success) {
+            printf("  Failed to set USB device iterator: %s\n", error_message);
+        } else {
+            printf("  Display: ");
+            print_usb_device(devices[i]);
+        }
+
+        err = fw_usb_device_set(
+            devices[i],
+            fw_usbdevice_iter_fpga,
+            error_message,
+            &error_message_size
+        );
+        if (err != fw_error_success) {
+            printf("  Failed to set USB device iterator: %s\n", error_message);
+        } else {
+            printf("  FPGA: ");
+            print_usb_device(devices[i]);
+        }
+
+        err = fw_usb_device_set(
+            devices[i],
+            fw_usbdevice_iter_hub,
+            error_message,
+            &error_message_size
+        );
+        if (err != fw_error_success) {
+            printf("  Failed to set USB device iterator: %s\n", error_message);
+        } else {
+            printf("  Hub: ");
+            print_usb_device(devices[i]);
+        }
+
         printf("  Total USB Devices: %u\n", usb_count);
         printf("  USB Devices:\n");
 
-        // Enumerate USB devices
-        for (uint32_t j = 0; j < usb_count; ++j) {
-            char usb_name[128] = { 0 };
-            char usb_serial[128] = { 0 };
-            uint32_t vid = 0, pid = 0, location = 0;
-
-            // Get USB device strings
-            err = fw_usb_device_get_str(devices[i], fw_stringtype_name, usb_name, sizeof(usb_name));
-            if (err != fw_error_success) {
-                printf("    USB Device %u: Failed to get name\n", j + 1);
-                goto next_usb_device;
-            }
-
-            err = fw_usb_device_get_str(
-                devices[i],
-                fw_stringtype_serial,
-                usb_serial,
-                sizeof(usb_serial)
-            );
-            if (err != fw_error_success) {
-                printf("    USB Device %u: Failed to get serial\n", j + 1);
-                goto next_usb_device;
-            }
-
-            // Get USB device integers (VID, PID, Location)
-            err = fw_usb_device_get_int(devices[i], fw_inttype_vid, &vid);
-            if (err != fw_error_success) {
-                printf("    USB Device %u: Failed to get VID\n", j + 1);
-                goto next_usb_device;
-            }
-
-            err = fw_usb_device_get_int(devices[i], fw_inttype_pid, &pid);
-            if (err != fw_error_success) {
-                printf("    USB Device %u: Failed to get PID\n", j + 1);
-                goto next_usb_device;
-            }
-
-            err = fw_usb_device_get_int(devices[i], fw_inttype_location, &location);
-            if (err != fw_error_success) {
-                printf("    USB Device %u: Failed to get location\n", j + 1);
-                goto next_usb_device;
-            }
-
-            printf("    USB Device %u: %s\n", j + 1, usb_name);
-            printf("      Serial: %s\n", usb_serial);
-            printf("      VID: 0x%04X, PID: 0x%04X, Location: %u\n", vid, pid, location);
-
-            // Try to get port information (for serial devices)
-            char port[128] = { 0 };
-            if (fw_usb_device_get_str(devices[i], fw_stringtype_port, port, sizeof(port))
-                == fw_error_success)
-            {
-                printf("      Port: %s\n", port);
-            }
-
-            // Try to get path information (for mass storage devices)
-            char path[256] = { 0 };
-            if (fw_usb_device_get_str(devices[i], fw_stringtype_path, path, sizeof(path))
-                == fw_error_success)
-            {
-                printf("      Path: %s\n", path);
-            }
-
-        next_usb_device:
-            // Move to the next USB device
-            if (j < usb_count - 1) {
-                err = fw_usb_device_next(devices[i]);
-                if (err != fw_error_success) {
-                    printf("    Failed to move to next USB device\n");
-                    break;
-                }
-            }
+        // Begin USB device enumeration
+        err = fw_usb_device_begin(devices[i]);
+        if (err != fw_error_success) {
+            printf("  Failed to begin USB device enumeration\n");
+            continue;
         }
-
-        printf("\n");
+        do {
+            err = print_usb_device(devices[i]);
+            if (err != fw_error_success) {
+                printf("    Failed to print USB device information\n");
+                break;
+            }
+        } while ((err = fw_usb_device_next(devices[i])) == fw_error_success);
     }
-
     // Free the devices
     err = fw_device_free(devices, device_count);
     if (err != fw_error_success) {
@@ -168,4 +168,72 @@ int main(void) {
     }
 
     return 0;
+}
+
+fw_error_t print_usb_device(fw_freewili_device_t* device) {
+    if (device == NULL) {
+        return fw_error_invalid_parameter;
+    }
+
+    char usb_name[128] = { 0 };
+    char usb_serial[128] = { 0 };
+    uint32_t vid = 0, pid = 0, location = 0;
+
+    // Get USB device strings
+    fw_error_t err = fw_usb_device_get_str(device, fw_stringtype_name, usb_name, sizeof(usb_name));
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    err = fw_usb_device_get_str(device, fw_stringtype_serial, usb_serial, sizeof(usb_serial));
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    // Get USB device integers (VID, PID, Location)
+    err = fw_usb_device_get_int(device, fw_inttype_vid, &vid);
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    err = fw_usb_device_get_int(device, fw_inttype_pid, &pid);
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    err = fw_usb_device_get_int(device, fw_inttype_location, &location);
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    fw_usbdevicetype_t usb_device_type;
+    err = fw_usb_device_get_type(device, &usb_device_type);
+    if (err != fw_error_success) {
+        return err;
+    }
+    char usb_type_name[128] = { 0 };
+    uint32_t usb_type_name_size = sizeof(usb_type_name);
+    err = fw_usb_device_get_type_name(usb_device_type, usb_type_name, &usb_type_name_size);
+    if (err != fw_error_success) {
+        return err;
+    }
+
+    printf("    USB Device %u: %s\n", location, usb_name);
+    printf("      Serial: %s\n", usb_serial);
+    printf("      VID: 0x%04X, PID: 0x%04X, Location: %u\n", vid, pid, location);
+    printf("      Type: %s\n", usb_type_name);
+
+    // Try to get port information (for serial devices)
+    char port[128] = { 0 };
+    if (fw_usb_device_get_str(device, fw_stringtype_port, port, sizeof(port)) == fw_error_success) {
+        printf("      Port: %s\n", port);
+    }
+
+    // Try to get path information (for mass storage devices)
+    char path[256] = { 0 };
+    if (fw_usb_device_get_str(device, fw_stringtype_path, path, sizeof(path)) == fw_error_success) {
+        printf("      Path: %s\n", path);
+    }
+
+    return fw_error_success;
 }

--- a/examples/c_api_basic_usage.c
+++ b/examples/c_api_basic_usage.c
@@ -12,6 +12,7 @@
 #include <cfwfinder.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 fw_error_t print_usb_device(fw_freewili_device_t* device);
 
@@ -82,7 +83,7 @@ int main(void) {
         printf("  Serial: %s\n", serial);
         printf("  Type: %s\n", type);
         printf("  Standalone: %s\n", is_standalone ? "Yes" : "No");
-        printf("  Unique ID: %lu\n", unique_id);
+        printf("  Unique ID: %" PRIu64 "\n", unique_id);
 
         // Get USB device count
         uint32_t usb_count = 0;

--- a/examples/test_port_chain.cpp
+++ b/examples/test_port_chain.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file test_port_chain.cpp
+ * @brief Example demonstrating USB port chain analysis after locationID refactoring
+ *
+ * This example shows how the refactored locationID parsing works on macOS:
+ * - Location: represents the actual port number on the immediate parent hub/controller
+ * - PortChain: represents the full path from root hub to the device
+ * 
+ * Following the cyme project's approach for macOS USB location identification.
+ */
+
+#include <fwfinder.hpp>
+#include <iostream>
+#include <iomanip>
+
+int main() {
+    std::cout << "Testing locationID refactoring - Port Chain Analysis" << std::endl;
+    std::cout << "====================================================" << std::endl << std::endl;
+
+    if (auto fw_devices = Fw::find_all(); fw_devices.has_value()) {
+        const auto& devices = fw_devices.value();
+
+        std::cout << "Found " << devices.size() << " FreeWili device(s):" << std::endl << std::endl;
+
+        for (size_t i = 0; i < devices.size(); ++i) {
+            const auto& device = devices[i];
+
+            std::cout << "Device " << (i + 1) << ": " << device.name << std::endl;
+            std::cout << "  Serial: " << device.serial << std::endl;
+            std::cout << "  USB Devices with Port Chain Analysis:" << std::endl;
+
+            for (const auto& usb : device.usbDevices) {
+                std::cout << "    - " << usb.name << std::endl;
+                std::cout << "      Location (port): " << usb.location << std::endl;
+                std::cout << "      Port Chain: [";
+                for (size_t j = 0; j < usb.portChain.size(); ++j) {
+                    std::cout << usb.portChain[j];
+                    if (j < usb.portChain.size() - 1) std::cout << ", ";
+                }
+                std::cout << "]" << std::endl;
+                std::cout << "      Type: " << Fw::getUSBDeviceTypeName(usb.kind) << std::endl;
+                std::cout << "      VID:PID: 0x" << std::hex << std::setw(4) << std::setfill('0') 
+                          << usb.vid << ":0x" << std::hex << std::setw(4) << std::setfill('0') 
+                          << usb.pid << std::dec << std::endl;
+                std::cout << std::endl;
+            }
+        }
+    } else {
+        std::cerr << "Failed to find FreeWili devices: " << fw_devices.error() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/include/fwbuilder.hpp
+++ b/include/fwbuilder.hpp
@@ -9,12 +9,12 @@ namespace Fw {
 
 /**
  * @brief Builder class for constructing FreeWiliDevice objects with validation.
- * 
+ *
  * The FreeWiliDeviceBuilder provides a fluent interface for creating FreeWiliDevice
  * objects with proper validation of required fields. All parameters are optional
  * during construction, but validation occurs during the build() call to ensure
  * all required fields are set.
- * 
+ *
  * @code{.cpp}
  * auto device = Fw::FreeWiliDevice::builder()
  *     .setDeviceType(Fw::DeviceType::FreeWili)
@@ -23,7 +23,7 @@ namespace Fw {
  *     .setUniqueID(Fw::generateUniqueID(0, 0))
  *     .setUSBDevices(std::move(usbDevices))
  *     .build();
- * 
+ *
  * if (device.has_value()) {
  *     // Use device.value()
  * } else {
@@ -48,15 +48,15 @@ public:
 
     /**
      * @brief Sets the device type for the FreeWiliDevice being built.
-     * 
-     * @param type The type of device (FreeWili, DefCon badge, etc.)
+     *
+     * @param type The type of device (FreeWili, DEFCON badge, etc.)
      * @return Reference to this builder for method chaining
      */
     FreeWiliDeviceBuilder& setDeviceType(Fw::DeviceType type);
 
     /**
      * @brief Sets the name for the FreeWiliDevice being built.
-     * 
+     *
      * @param name The human-readable name of the device
      * @return Reference to this builder for method chaining
      */
@@ -64,7 +64,7 @@ public:
 
     /**
      * @brief Sets the serial number for the FreeWiliDevice being built.
-     * 
+     *
      * @param serial The unique serial number of the device
      * @return Reference to this builder for method chaining
      */
@@ -72,7 +72,7 @@ public:
 
     /**
      * @brief Sets the unique ID for the FreeWiliDevice being built.
-     * 
+     *
      * @param id The unique 64-bit identifier for the device
      * @return Reference to this builder for method chaining
      */
@@ -80,14 +80,14 @@ public:
 
     /**
      * @brief Sets the standalone status for the FreeWiliDevice being built.
-     * 
+     *
      * @param standalone True if the device is standalone, false otherwise
      * @return Reference to this builder for method chaining
      */
     FreeWiliDeviceBuilder& setStandalone(bool standalone);
     /**
      * @brief Sets the USB devices list for the FreeWiliDevice being built (copy).
-     * 
+     *
      * @param devices Vector of USB devices associated with this FreeWili device
      * @return Reference to this builder for method chaining
      */
@@ -95,7 +95,7 @@ public:
 
     /**
      * @brief Sets the USB devices list for the FreeWiliDevice being built (move).
-     * 
+     *
      * @param devices Vector of USB devices associated with this FreeWili device
      * @return Reference to this builder for method chaining
      */
@@ -103,11 +103,11 @@ public:
 
     /**
      * @brief Builds and validates the FreeWiliDevice.
-     * 
+     *
      * Validates that all required fields have been set and constructs a
      * FreeWiliDevice object. If any required field is missing, returns
      * an error describing which field is missing.
-     * 
+     *
      * @return std::expected containing either a valid FreeWiliDevice or an error message
      */
     std::expected<FreeWiliDevice, std::string> build();
@@ -115,8 +115,8 @@ public:
 private:
     /**
      * @brief Validates that all required fields have been set.
-     * 
-     * @return std::optional containing an error message if validation fails, 
+     *
+     * @return std::optional containing an error message if validation fails,
      *         or std::nullopt if all fields are valid
      */
     std::optional<std::string> validate() const;

--- a/include/fwbuilder.hpp
+++ b/include/fwbuilder.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <fwfinder.hpp>
+#include <optional>
+#include <expected>
+#include <string>
+
+namespace Fw {
+
+/**
+ * @brief Builder class for constructing FreeWiliDevice objects with validation.
+ * 
+ * The FreeWiliDeviceBuilder provides a fluent interface for creating FreeWiliDevice
+ * objects with proper validation of required fields. All parameters are optional
+ * during construction, but validation occurs during the build() call to ensure
+ * all required fields are set.
+ * 
+ * @code{.cpp}
+ * auto device = Fw::FreeWiliDevice::builder()
+ *     .setDeviceType(Fw::DeviceType::FreeWili)
+ *     .setName("My Device")
+ *     .setSerial("ABC123")
+ *     .setUniqueID(Fw::generateUniqueID(0, 0))
+ *     .setUSBDevices(std::move(usbDevices))
+ *     .build();
+ * 
+ * if (device.has_value()) {
+ *     // Use device.value()
+ * } else {
+ *     // Handle error: device.error()
+ * }
+ * @endcode
+ */
+class FreeWiliDeviceBuilder {
+private:
+    std::optional<Fw::DeviceType> deviceType_;
+    std::optional<std::string> name_;
+    std::optional<std::string> serial_;
+    std::optional<uint64_t> uniqueID_;
+    std::optional<Fw::USBDevices> usbDevices_;
+
+public:
+    /**
+     * @brief Default constructor for FreeWiliDeviceBuilder.
+     */
+    FreeWiliDeviceBuilder() = default;
+
+    /**
+     * @brief Sets the device type for the FreeWiliDevice being built.
+     * 
+     * @param type The type of device (FreeWili, DefCon badge, etc.)
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setDeviceType(Fw::DeviceType type);
+
+    /**
+     * @brief Sets the name for the FreeWiliDevice being built.
+     * 
+     * @param name The human-readable name of the device
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setName(const std::string& name);
+
+    /**
+     * @brief Sets the serial number for the FreeWiliDevice being built.
+     * 
+     * @param serial The unique serial number of the device
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setSerial(const std::string& serial);
+
+    /**
+     * @brief Sets the unique ID for the FreeWiliDevice being built.
+     * 
+     * @param id The unique 64-bit identifier for the device
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setUniqueID(uint64_t id);
+
+    /**
+     * @brief Sets the USB devices list for the FreeWiliDevice being built (copy).
+     * 
+     * @param devices Vector of USB devices associated with this FreeWili device
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setUSBDevices(const Fw::USBDevices& devices);
+
+    /**
+     * @brief Sets the USB devices list for the FreeWiliDevice being built (move).
+     * 
+     * @param devices Vector of USB devices associated with this FreeWili device
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setUSBDevices(Fw::USBDevices&& devices);
+
+    /**
+     * @brief Builds and validates the FreeWiliDevice.
+     * 
+     * Validates that all required fields have been set and constructs a
+     * FreeWiliDevice object. If any required field is missing, returns
+     * an error describing which field is missing.
+     * 
+     * @return std::expected containing either a valid FreeWiliDevice or an error message
+     */
+    std::expected<FreeWiliDevice, std::string> build();
+
+private:
+    /**
+     * @brief Validates that all required fields have been set.
+     * 
+     * @return std::optional containing an error message if validation fails, 
+     *         or std::nullopt if all fields are valid
+     */
+    std::optional<std::string> validate() const;
+};
+
+} // namespace Fw

--- a/include/fwbuilder.hpp
+++ b/include/fwbuilder.hpp
@@ -38,6 +38,7 @@ private:
     std::optional<std::string> serial_;
     std::optional<uint64_t> uniqueID_;
     std::optional<Fw::USBDevices> usbDevices_;
+    std::optional<bool> standalone_;
 
 public:
     /**
@@ -77,6 +78,13 @@ public:
      */
     FreeWiliDeviceBuilder& setUniqueID(uint64_t id);
 
+    /**
+     * @brief Sets the standalone status for the FreeWiliDevice being built.
+     * 
+     * @param standalone True if the device is standalone, false otherwise
+     * @return Reference to this builder for method chaining
+     */
+    FreeWiliDeviceBuilder& setStandalone(bool standalone);
     /**
      * @brief Sets the USB devices list for the FreeWiliDevice being built (copy).
      * 

--- a/include/fwfinder.hpp
+++ b/include/fwfinder.hpp
@@ -71,6 +71,9 @@ struct USBDevice {
     /// USB physical location, 1 = first port
     uint32_t location;
 
+    /// USB port chain
+    std::vector<uint32_t> portChain;
+
     /// USB Mass storage Path - This is only valid when kind is MassStorage
     std::optional<std::vector<std::string>> paths;
     /// Serial Port Path - This is only valid when kind is Serial
@@ -184,25 +187,5 @@ typedef std::vector<FreeWiliDevice> FreeWiliDevices;
    * }
    */
 auto find_all() noexcept -> std::expected<FreeWiliDevices, std::string>;
-
-/**
- * @brief Generates a unique 64-bit ID from parent and device USB locations.
- *
- * Creates a hierarchical unique identifier by combining the parent USB controller
- * location in the upper 32 bits and the device's own USB location in the lower
- * 32 bits. This allows for consistent device identification across USB topology
- * changes while maintaining hierarchical relationships.
- *
- * @param parentLocation The USB location of the parent device (upper 32 bits)
- * @param deviceLocation The USB location of the device itself (lower 32 bits)
- * @return A 64-bit unique identifier combining both locations
- *
- * @code{.cpp}
- * // Example: Parent at location 2, device at location 5
- * uint64_t uniqueId = Fw::generateUniqueID(2, 5);
- * // Result: 0x0000000200000005
- * @endcode
- */
-auto generateUniqueID(uint32_t parentLocation, uint32_t deviceLocation) -> uint64_t;
 
 }; // namespace Fw

--- a/include/fwfinder.hpp
+++ b/include/fwfinder.hpp
@@ -78,6 +78,8 @@ struct USBDevice {
 
     /// Internal system path of the USBDevice
     std::string _raw;
+
+    bool operator==(const USBDevice& other) const noexcept = default;
 };
 
 /// Container of all USB Devices.
@@ -100,10 +102,10 @@ struct FreeWiliDevice {
 
     // Copy constructor
     FreeWiliDevice(const FreeWiliDevice& other) = default;
-    
+
     // Move constructor
     FreeWiliDevice(FreeWiliDevice&& other) noexcept;
-    
+
     // Copy assignment operator
     FreeWiliDevice& operator=(const FreeWiliDevice& other) = default;
 
@@ -141,11 +143,21 @@ struct FreeWiliDevice {
 private:
     // Private constructor for builder pattern - only accessible by FreeWiliDeviceBuilder
     friend class FreeWiliDeviceBuilder;
-    
-    FreeWiliDevice(Fw::DeviceType type, const std::string& name, const std::string& serial, 
-                uint64_t id, bool standalone, Fw::USBDevices&& devices) 
-    : deviceType(type), name(name), serial(serial), uniqueID(id), standalone(standalone), usbDevices(std::move(devices)) {}
 
+    FreeWiliDevice(
+        Fw::DeviceType type,
+        const std::string& name,
+        const std::string& serial,
+        uint64_t id,
+        bool standalone,
+        Fw::USBDevices&& devices
+    ):
+        deviceType(type),
+        name(name),
+        serial(serial),
+        uniqueID(id),
+        standalone(standalone),
+        usbDevices(std::move(devices)) {}
 };
 
 /// Free-Wili Devices

--- a/include/fwfinder.hpp
+++ b/include/fwfinder.hpp
@@ -21,8 +21,8 @@ enum class USBHubPortLocation : uint32_t {
 enum class DeviceType : uint32_t {
     Unknown = 0,
     FreeWili = 1,
-    DefCon2024Badge = 2,
-    DefCon2025FwBadge = 3,
+    DEFCON2024Badge = 2,
+    DEFCON2025FwBadge = 3,
     UF2 = 4,
     Winky = 5,
 };
@@ -131,7 +131,7 @@ struct FreeWiliDevice {
 
     /**
      * @brief Creates a new FreeWiliDeviceBuilder for constructing FreeWiliDevice objects.
-     * 
+     *
      * @return A new FreeWiliDeviceBuilder instance for fluent construction
      */
     static FreeWiliDeviceBuilder builder();

--- a/include/fwfinder.hpp
+++ b/include/fwfinder.hpp
@@ -94,6 +94,8 @@ struct FreeWiliDevice {
     // changes.
     uint64_t uniqueID;
 
+    bool standalone;
+
     USBDevices usbDevices;
 
     // Copy constructor
@@ -141,8 +143,8 @@ private:
     friend class FreeWiliDeviceBuilder;
     
     FreeWiliDevice(Fw::DeviceType type, const std::string& name, const std::string& serial, 
-                uint64_t id, Fw::USBDevices&& devices) 
-    : deviceType(type), name(name), serial(serial), uniqueID(id), usbDevices(std::move(devices)) {}
+                uint64_t id, bool standalone, Fw::USBDevices&& devices) 
+    : deviceType(type), name(name), serial(serial), uniqueID(id), standalone(standalone), usbDevices(std::move(devices)) {}
 
 };
 

--- a/include/fwfinder.hpp
+++ b/include/fwfinder.hpp
@@ -8,6 +8,13 @@
 
 namespace Fw {
 
+/// Location of the USB device on the FreeWili Classic hub
+enum class USBHubPortLocation : uint32_t {
+    Main = 1,
+    Display = 2,
+    FPGA = 3,
+};
+
 enum class DeviceType : uint32_t {
     Unknown = 0,
     FreeWili = 1,
@@ -58,7 +65,7 @@ struct USBDevice {
     std::string name;
     /// Serial of the device
     std::string serial;
-    /// USB physical location, 0 = first port
+    /// USB physical location, 1 = first port
     uint32_t location;
 
     /// USB Mass storage Path - This is only valid when kind is MassStorage
@@ -79,16 +86,35 @@ struct FreeWiliDevice {
     std::string name;
     std::string serial;
 
+    // This is a unique ID based on location so we
+    // can identify devices when the configuration
+    // changes.
+    uint64_t uniqueID;
+
     USBDevices usbDevices;
 
+    // Get all USB devices attached to the USB Hub
+    // On standalone devices like the badge this will return Main only.
+    // specifying an empty vector will return all.
+    auto getUSBDevices(std::vector<USBDeviceType> usbDeviceTypes) const noexcept -> USBDevices;
     auto getUSBDevices(USBDeviceType usbDeviceType) const noexcept -> USBDevices;
+    auto getUSBDevices() const noexcept -> USBDevices;
+
+    // Get the Main Processor as a USBDevice
+    auto getMainUSBDevice() const noexcept -> std::expected<USBDevice, std::string>;
+    // Get the Display Processor as a USBDevice
+    auto getDisplayUSBDevice() const noexcept -> std::expected<USBDevice, std::string>;
+    // Get the FPGA Processor as a USBDevice
+    auto getFPGAUSBDevice() const noexcept -> std::expected<USBDevice, std::string>;
+    // Get the Hub as a USBDevice
+    auto getHubUSBDevice() const noexcept -> std::expected<USBDevice, std::string>;
 
     /// Helper function to create a FreeWiliDevice from USBDevices
     static auto fromUSBDevices(const USBDevices& usbDevices)
         -> std::expected<FreeWiliDevice, std::string>;
 
     bool operator==(const FreeWiliDevice& other) const noexcept {
-        return name == other.name && serial == other.serial;
+        return uniqueID == other.uniqueID;
     }
 };
 

--- a/include/usbdef.hpp
+++ b/include/usbdef.hpp
@@ -36,9 +36,9 @@ const uint16_t USB_PID_FW_ESP32_SERIAL = 0xEA60;
 
 /// FreeWili Winky Product ID
 const uint16_t USB_PID_FW_WINKY = 0x2056;
-/// DefCon 2024 Badge Product ID
+/// DEFCON 2024 Badge Product ID
 const uint16_t USB_PID_FW_DEFCON_2024 = 0x2057;
-/// DefCon 2025 FreeWili Badge Product ID
+/// DEFCON 2025 FreeWili Badge Product ID
 const uint16_t USB_PID_FW_DEFCON_BADGE_2025 = 0x2058;
 
 static std::map<uint16_t, std::vector<uint16_t>> WhitelistVIDPID = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pyfwfinder"
-version = "0.3.0"
-description = "An example minimal project that compiles bindings using nanobind and scikit-build"
+version = "0.4.0"
+description = "Python API to find Free-WiLi devices"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [{ name = "David Rebbe", email = "drebbe@intrepidcs.com" }]

--- a/src/fwbuilder.cpp
+++ b/src/fwbuilder.cpp
@@ -23,6 +23,11 @@ FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setUniqueID(uint64_t id) {
     return *this;
 }
 
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setStandalone(bool standalone) {
+    standalone_ = standalone;
+    return *this;
+}
+
 FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setUSBDevices(const Fw::USBDevices& devices) {
     usbDevices_ = devices;
     return *this;
@@ -44,6 +49,7 @@ std::expected<FreeWiliDevice, std::string> FreeWiliDeviceBuilder::build() {
         name_.value(),
         serial_.value(),
         uniqueID_.value(),
+        standalone_.value(),
         std::move(usbDevices_.value())
     );
 }
@@ -80,6 +86,10 @@ std::optional<std::string> FreeWiliDeviceBuilder::validate() const {
 
     if (deviceType_.value() == DeviceType::Unknown) {
         return "Device type cannot be Unknown";
+    }
+
+    if (!standalone_.has_value()) {
+        return "Device standalone status is required but not set";
     }
 
     return std::nullopt; // No validation errors

--- a/src/fwbuilder.cpp
+++ b/src/fwbuilder.cpp
@@ -1,0 +1,88 @@
+#include <fwbuilder.hpp>
+#include <limits>
+
+namespace Fw {
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setDeviceType(Fw::DeviceType type) {
+    deviceType_ = type;
+    return *this;
+}
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setName(const std::string& name) {
+    name_ = name;
+    return *this;
+}
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setSerial(const std::string& serial) {
+    serial_ = serial;
+    return *this;
+}
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setUniqueID(uint64_t id) {
+    uniqueID_ = id;
+    return *this;
+}
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setUSBDevices(const Fw::USBDevices& devices) {
+    usbDevices_ = devices;
+    return *this;
+}
+
+FreeWiliDeviceBuilder& FreeWiliDeviceBuilder::setUSBDevices(Fw::USBDevices&& devices) {
+    usbDevices_ = std::move(devices);
+    return *this;
+}
+
+std::expected<FreeWiliDevice, std::string> FreeWiliDeviceBuilder::build() {
+    if (auto error = validate(); error.has_value()) {
+        return std::unexpected(error.value());
+    }
+
+    // All required fields are present, construct the device
+    return FreeWiliDevice(
+        deviceType_.value(),
+        name_.value(),
+        serial_.value(),
+        uniqueID_.value(),
+        std::move(usbDevices_.value())
+    );
+}
+
+std::optional<std::string> FreeWiliDeviceBuilder::validate() const {
+    if (!deviceType_.has_value()) {
+        return "Device type is required but not set";
+    }
+
+    if (!name_.has_value()) {
+        return "Device name is required but not set";
+    }
+
+    if (!serial_.has_value()) {
+        return "Device serial is required but not set";
+    }
+
+    if (!uniqueID_.has_value()) {
+        return "Device unique ID is required but not set";
+    }
+
+    if (!usbDevices_.has_value()) {
+        return "USB devices list is required but not set";
+    }
+
+    // Additional validation checks
+    if (name_.value().empty()) {
+        return "Device name cannot be empty";
+    }
+
+    if (serial_.value().empty()) {
+        return "Device serial cannot be empty";
+    }
+
+    if (deviceType_.value() == DeviceType::Unknown) {
+        return "Device type cannot be Unknown";
+    }
+
+    return std::nullopt; // No validation errors
+}
+
+} // namespace Fw

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <sstream>
 #include <cassert>
+#include <limits>
 
 auto _generateUniqueIDFromUSBPortChain(const std::vector<uint32_t>& usbPortChain) -> uint64_t {
     // Limitation: We can do 10 hubs deep and 64 ports per hub with 6 bits allocated per port.

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -215,3 +215,70 @@ auto Fw::generateUniqueID(uint32_t parentLocation, uint32_t deviceLocation) -> u
 Fw::FreeWiliDeviceBuilder Fw::FreeWiliDevice::builder() {
     return Fw::FreeWiliDeviceBuilder();
 }
+
+auto Fw::FreeWiliDevice::getMainUSBDevice() const noexcept
+    -> std::expected<USBDevice, std::string> {
+    if (auto it = std::find_if(
+            usbDevices.begin(),
+            usbDevices.end(),
+            [&](const USBDevice& usb_dev) {
+                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::Main)
+                    && usb_dev.kind != Fw::USBDeviceType::Hub
+                    && usb_dev.kind != Fw::USBDeviceType::Other;
+            }
+        );
+        it != usbDevices.end())
+    {
+        return *it;
+    }
+    return std::unexpected("Main USB device not found");
+}
+
+auto Fw::FreeWiliDevice::getDisplayUSBDevice() const noexcept
+    -> std::expected<USBDevice, std::string> {
+    if (auto it = std::find_if(
+            usbDevices.begin(),
+            usbDevices.end(),
+            [&](const USBDevice& usb_dev) {
+                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::Display)
+                    && usb_dev.kind != Fw::USBDeviceType::Hub
+                    && usb_dev.kind != Fw::USBDeviceType::Other;
+            }
+        );
+        it != usbDevices.end())
+    {
+        return *it;
+    }
+    return std::unexpected("Display USB device not found");
+}
+
+auto Fw::FreeWiliDevice::getFPGAUSBDevice() const noexcept
+    -> std::expected<USBDevice, std::string> {
+    if (auto it = std::find_if(
+            usbDevices.begin(),
+            usbDevices.end(),
+            [&](const USBDevice& usb_dev) {
+                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA)
+                    && usb_dev.kind != Fw::USBDeviceType::Hub
+                    && usb_dev.kind != Fw::USBDeviceType::Other;
+            }
+        );
+        it != usbDevices.end())
+    {
+        return *it;
+    }
+    return std::unexpected("FPGA USB device not found");
+}
+
+auto Fw::FreeWiliDevice::getHubUSBDevice() const noexcept -> std::expected<USBDevice, std::string> {
+    if (auto it = std::find_if(
+            usbDevices.begin(),
+            usbDevices.end(),
+            [&](const USBDevice& usb_dev) { return usb_dev.kind == Fw::USBDeviceType::Hub; }
+        );
+        it != usbDevices.end())
+    {
+        return *it;
+    }
+    return std::unexpected("Hub USB device not found");
+}

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -157,7 +157,8 @@ auto Fw::FreeWiliDevice::fromUSBDevices(const Fw::USBDevices& usbDevices)
             sortedUsbDevices.end(),
             [](const Fw::USBDevice& lhs, const Fw::USBDevice& rhs) {
                 // Always put the hub at the bottom
-                if (rhs.kind == Fw::USBDeviceType::Hub) {
+                if (lhs.kind == Fw::USBDeviceType::Hub ||
+                    rhs.kind == Fw::USBDeviceType::Hub) {
                     return false;
                 }
                 // order smallest to largest

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -9,14 +9,17 @@
 #include <cassert>
 
 auto _generateUniqueIDFromUSBPortChain(const std::vector<uint32_t>& usbPortChain) -> uint64_t {
+    // Limitation: We can do 10 hubs deep and 64 ports per hub with 6 bits allocated per port.
+    // Currently USB 3.0 controller max out at 64 devices. The spec states 128 per controller,
+    // but I have yet to see this in practice as of September 2025.
+    const auto bitsPerPort = 6; // Make sure the mask below matches this
     assert(usbPortChain.size() != 0 && "USB port chain cannot be empty");
     assert(
-        usbPortChain.size() <= std::numeric_limits<uint64_t>::digits / 32
+        usbPortChain.size() <= std::numeric_limits<uint64_t>::digits / bitsPerPort
         && "USB port chain too deep"
     );
 
     uint64_t uniqueID = 0;
-    const auto bitsPerPort = 6;
     auto i = 0;
     for (const uint32_t& port: usbPortChain) {
         uniqueID |= (port & 0x3F) << (bitsPerPort * i++);

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -220,20 +220,20 @@ Fw::FreeWiliDeviceBuilder Fw::FreeWiliDevice::builder() {
 auto Fw::FreeWiliDevice::getMainUSBDevice() const noexcept
     -> std::expected<USBDevice, std::string> {
     if (standalone) {
-        if (usbDevices.size() == 1 && isStandAloneDevice(usbDevices[0].vid, usbDevices[0].pid)) {
+        if (usbDevices.size() && isStandAloneDevice(usbDevices[0].vid, usbDevices[0].pid)) {
             return usbDevices[0];
         }
-    }
-    else if (auto it = std::find_if(
-            usbDevices.begin(),
-            usbDevices.end(),
-            [&](const USBDevice& usb_dev) {
-                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::Main)
-                    && usb_dev.kind != Fw::USBDeviceType::Hub
-                    && usb_dev.kind != Fw::USBDeviceType::Other;
-            }
-        );
-        it != usbDevices.end())
+    } else if (auto it = std::find_if(
+                   usbDevices.begin(),
+                   usbDevices.end(),
+                   [&](const USBDevice& usb_dev) {
+                       return usb_dev.location
+                           == static_cast<uint32_t>(Fw::USBHubPortLocation::Main)
+                           && usb_dev.kind != Fw::USBDeviceType::Hub
+                           && usb_dev.kind != Fw::USBDeviceType::Other;
+                   }
+               );
+               it != usbDevices.end())
     {
         return *it;
     }
@@ -244,19 +244,20 @@ auto Fw::FreeWiliDevice::getDisplayUSBDevice() const noexcept
     -> std::expected<USBDevice, std::string> {
     if (standalone) {
         std::stringstream ss;
-        ss << getDeviceTypeName(deviceType) << " is a standalone device and has no Display USB device.";
+        ss << getDeviceTypeName(deviceType)
+           << " is a standalone device and has no Display USB device.";
         return std::unexpected(ss.str());
-    }
-    else if (auto it = std::find_if(
-            usbDevices.begin(),
-            usbDevices.end(),
-            [&](const USBDevice& usb_dev) {
-                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::Display)
-                    && usb_dev.kind != Fw::USBDeviceType::Hub
-                    && usb_dev.kind != Fw::USBDeviceType::Other;
-            }
-        );
-        it != usbDevices.end())
+    } else if (auto it = std::find_if(
+                   usbDevices.begin(),
+                   usbDevices.end(),
+                   [&](const USBDevice& usb_dev) {
+                       return usb_dev.location
+                           == static_cast<uint32_t>(Fw::USBHubPortLocation::Display)
+                           && usb_dev.kind != Fw::USBDeviceType::Hub
+                           && usb_dev.kind != Fw::USBDeviceType::Other;
+                   }
+               );
+               it != usbDevices.end())
     {
         return *it;
     }
@@ -267,18 +268,20 @@ auto Fw::FreeWiliDevice::getFPGAUSBDevice() const noexcept
     -> std::expected<USBDevice, std::string> {
     if (standalone) {
         std::stringstream ss;
-        ss << getDeviceTypeName(deviceType) << " is a standalone device and has no FPGA USB device.";
+        ss << getDeviceTypeName(deviceType)
+           << " is a standalone device and has no FPGA USB device.";
         return std::unexpected(ss.str());
     } else if (auto it = std::find_if(
-            usbDevices.begin(),
-            usbDevices.end(),
-            [&](const USBDevice& usb_dev) {
-                return usb_dev.location == static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA)
-                    && usb_dev.kind != Fw::USBDeviceType::Hub
-                    && usb_dev.kind != Fw::USBDeviceType::Other;
-            }
-        );
-        it != usbDevices.end())
+                   usbDevices.begin(),
+                   usbDevices.end(),
+                   [&](const USBDevice& usb_dev) {
+                       return usb_dev.location
+                           == static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA)
+                           && usb_dev.kind != Fw::USBDeviceType::Hub
+                           && usb_dev.kind != Fw::USBDeviceType::Other;
+                   }
+               );
+               it != usbDevices.end())
     {
         return *it;
     }
@@ -291,11 +294,11 @@ auto Fw::FreeWiliDevice::getHubUSBDevice() const noexcept -> std::expected<USBDe
         ss << getDeviceTypeName(deviceType) << " is a standalone device and has no HUB USB device.";
         return std::unexpected(ss.str());
     } else if (auto it = std::find_if(
-            usbDevices.begin(),
-            usbDevices.end(),
-            [&](const USBDevice& usb_dev) { return usb_dev.kind == Fw::USBDeviceType::Hub; }
-        );
-        it != usbDevices.end())
+                   usbDevices.begin(),
+                   usbDevices.end(),
+                   [&](const USBDevice& usb_dev) { return usb_dev.kind == Fw::USBDeviceType::Hub; }
+               );
+               it != usbDevices.end())
     {
         return *it;
     }

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -63,10 +63,10 @@ auto Fw::getDeviceTypeName(Fw::DeviceType type) -> std::string {
     switch (type) {
         case Fw::DeviceType::FreeWili:
             return "Free-WiLi";
-        case Fw::DeviceType::DefCon2024Badge:
-            return "DefCon 2024 Badge";
-        case Fw::DeviceType::DefCon2025FwBadge:
-            return "DefCon 2025 Badge";
+        case Fw::DeviceType::DEFCON2024Badge:
+            return "DEFCON 2024 Badge";
+        case Fw::DeviceType::DEFCON2025FwBadge:
+            return "DEFCON 2025 Badge";
         case Fw::DeviceType::UF2:
             return "UF2";
         case Fw::DeviceType::Winky:
@@ -131,9 +131,9 @@ auto Fw::FreeWiliDevice::fromUSBDevices(const Fw::USBDevices& usbDevices)
         if (Fw::isStandAloneDevice(device.vid, device.pid)) {
             isStandaloneDevice = true;
             if (device.pid == Fw::USB_PID_FW_DEFCON_2024) {
-                deviceType = Fw::DeviceType::DefCon2024Badge;
+                deviceType = Fw::DeviceType::DEFCON2024Badge;
             } else if (device.pid == Fw::USB_PID_FW_DEFCON_BADGE_2025) {
-                deviceType = Fw::DeviceType::DefCon2025FwBadge;
+                deviceType = Fw::DeviceType::DEFCON2025FwBadge;
             } else if (device.pid == Fw::USB_PID_FW_WINKY) {
                 deviceType = Fw::DeviceType::Winky;
             } else if (device.pid == Fw::USB_PID_FW_RPI_2040_UF2_PID

--- a/src/fwfinder.cpp
+++ b/src/fwfinder.cpp
@@ -61,11 +61,11 @@ auto Fw::getUSBDeviceTypeName(Fw::USBDeviceType type) -> std::string {
 auto Fw::getDeviceTypeName(Fw::DeviceType type) -> std::string {
     switch (type) {
         case Fw::DeviceType::FreeWili:
-            return "FreeWili";
+            return "Free-WiLi";
         case Fw::DeviceType::DefCon2024Badge:
-            return "DefCon2024Badge";
+            return "DefCon 2024 Badge";
         case Fw::DeviceType::DefCon2025FwBadge:
-            return "DefCon2025FwBadge";
+            return "DefCon 2025 Badge";
         case Fw::DeviceType::UF2:
             return "UF2";
         case Fw::DeviceType::Winky:
@@ -75,15 +75,35 @@ auto Fw::getDeviceTypeName(Fw::DeviceType type) -> std::string {
     }
 }
 
-auto Fw::FreeWiliDevice::getUSBDevices(Fw::USBDeviceType usbDeviceType) const noexcept
+auto Fw::FreeWiliDevice::getUSBDevices(std::vector<Fw::USBDeviceType> usbDeviceTypes) const noexcept
     -> Fw::USBDevices {
+    // Helper function to see if a vector contains the DeviceType
+    auto contains = [&](const Fw::USBDeviceType other_type) {
+        return std::find_if(
+            usbDeviceTypes.begin(),
+            usbDeviceTypes.end(),
+            [&](const Fw::USBDeviceType& device_type) {
+                return device_type == other_type;
+            }
+        ) != usbDeviceTypes.end();
+    };
+
     Fw::USBDevices foundDevices;
     std::for_each(usbDevices.begin(), usbDevices.end(), [&](const USBDevice& usb_dev) {
-        if (usb_dev.kind == usbDeviceType) {
+        if (usbDeviceTypes.empty() || contains(usb_dev.kind)) {
             foundDevices.push_back(usb_dev);
         }
     });
     return foundDevices;
+}
+
+auto Fw::FreeWiliDevice::getUSBDevices(Fw::USBDeviceType usbDeviceType) const noexcept -> Fw::USBDevices {
+    std::vector<Fw::USBDeviceType> types = { usbDeviceType };
+    return getUSBDevices(types);
+}
+
+auto Fw::FreeWiliDevice::getUSBDevices() const noexcept -> Fw::USBDevices {
+    return usbDevices;
 }
 
 auto Fw::FreeWiliDevice::fromUSBDevices(const Fw::USBDevices& usbDevices)

--- a/src/fwfinder_linux.cpp
+++ b/src/fwfinder_linux.cpp
@@ -134,10 +134,10 @@ auto usbPortChainFromUdevDevice(udev_device* dev) -> std::vector<uint32_t> {
     }
 
     std::vector<uint32_t> portChain;
-    
+
     // Start with the current device and walk up the tree
     udev_device* current = dev;
-    
+
     while (current) {
         std::string sysnum;
         if (const char* value = udev_device_get_sysnum(current); value) {
@@ -146,7 +146,7 @@ auto usbPortChainFromUdevDevice(udev_device* dev) -> std::vector<uint32_t> {
         if (sysnum.empty()) {
             break;
         }
-        
+
         try {
             uint32_t num = static_cast<uint32_t>(std::stoul(sysnum));
             portChain.push_back(num);
@@ -154,18 +154,19 @@ auto usbPortChainFromUdevDevice(udev_device* dev) -> std::vector<uint32_t> {
             break;
         }
 
-        udev_device* parent = udev_device_get_parent_with_subsystem_devtype(current, "usb", "usb_device");
+        udev_device* parent =
+            udev_device_get_parent_with_subsystem_devtype(current, "usb", "usb_device");
         if (!parent) {
             break;
         }
-        
+
         // Move up to the parent for next iteration
         current = parent;
     }
-    
+
     // Reverse the chain so it goes from root to leaf
     std::reverse(portChain.begin(), portChain.end());
-    
+
     return portChain;
 }
 
@@ -387,7 +388,7 @@ auto _find_all_standalone(
     udev_enumerate_unref(enumerate);
     udev_unref(udev);
 
-    // Sort the devices by UniqueID instead of serial number
+    // Sort the devices by UniqueID
     std::sort(
         fwDevices.begin(),
         fwDevices.end(),
@@ -569,6 +570,15 @@ auto Fw::find_all() noexcept -> std::expected<Fw::FreeWiliDevices, std::string> 
     } else {
         return std::unexpected(result.error());
     }
+    // Sort the devices by unique ID
+    std::sort(
+        devices.begin(),
+        devices.end(),
+        [](const Fw::FreeWiliDevice& lhs, const Fw::FreeWiliDevice& rhs) {
+            // order smallest to largest
+            return lhs.uniqueID < rhs.uniqueID;
+        }
+    );
     return devices;
 }
 

--- a/src/fwfinder_mac.cpp
+++ b/src/fwfinder_mac.cpp
@@ -15,6 +15,8 @@
     #include <sstream>
     #include <map>
     #include <set>
+    #include <vector>
+    #include <algorithm>
 
 auto cfstrAsString(CFStringRef string_ref) noexcept -> std::string {
     if (string_ref == nullptr) {

--- a/src/fwfinder_mac.cpp
+++ b/src/fwfinder_mac.cpp
@@ -47,15 +47,15 @@ auto getUSBPortFromLocationID(uint32_t locationID) noexcept -> uint32_t {
     // macOS locationID format: 0xbbdddddd where:
     // - bb = bus number in hex
     // - dddddd = up to six levels for the tree, each digit represents position at that level
-    // 
+    //
     // Following the cyme project approach:
     // Extract the tree positions and return the last (rightmost) non-zero port number
     // which represents the port on the immediate parent hub/controller
-    
+
     // Extract the tree position digits (6 digits after bus)
     std::vector<uint32_t> treePositions;
     uint32_t locationDigits = locationID & 0x00FFFFFF; // Remove bus number
-    
+
     // Extract each hex digit from right to left, but we want left to right order
     for (int i = 20; i >= 0; i -= 4) { // 6 digits * 4 bits each = 24 bits
         uint32_t digit = (locationDigits >> i) & 0x0F;
@@ -63,13 +63,13 @@ auto getUSBPortFromLocationID(uint32_t locationID) noexcept -> uint32_t {
             treePositions.push_back(digit);
         }
     }
-    
+
     // The port number is the last (deepest) position in the tree
     // This represents the actual port on the immediate parent hub
     if (!treePositions.empty()) {
         return treePositions.back();
     }
-    
+
     // Fallback: if we can't extract meaningful tree positions,
     // this might be a root hub or special case
     return 1;
@@ -78,17 +78,17 @@ auto getUSBPortFromLocationID(uint32_t locationID) noexcept -> uint32_t {
 // Extract USB port chain from macOS locationID following cyme project approach
 auto getUSBPortChainFromLocationID(uint32_t locationID) noexcept -> std::vector<uint32_t> {
     // macOS locationID format: 0xbbdddddd where:
-    // - bb = bus number in hex  
+    // - bb = bus number in hex
     // - dddddd = up to six levels for the tree, each digit represents position at that level
     //
     // Following the cyme project approach for building the full port chain:
     // Extract each tree position digit from left to right to build the complete path
-    
+
     std::vector<uint32_t> portChain;
-    
+
     // Extract the tree position digits (6 digits after bus number)
     uint32_t locationDigits = locationID & 0x00FFFFFF; // Remove bus number (top 8 bits)
-    
+
     // Extract each hex digit from left to right (most significant to least significant)
     // Each digit represents the port number at that level in the USB tree
     for (int i = 20; i >= 0; i -= 4) { // 6 digits * 4 bits each = 24 bits, starting from left
@@ -97,7 +97,7 @@ auto getUSBPortChainFromLocationID(uint32_t locationID) noexcept -> std::vector<
             portChain.push_back(digit);
         }
     }
-    
+
     // If we couldn't extract any meaningful port chain, create a minimal one
     // This can happen for root hubs or devices directly connected to controller
     if (portChain.empty()) {
@@ -109,14 +109,13 @@ auto getUSBPortChainFromLocationID(uint32_t locationID) noexcept -> std::vector<
             portChain.push_back(1); // Default fallback
         }
     }
-    
+
     return portChain;
 }
 
 template<typename T>
-requires std::is_integral_v<T>
-auto getPropertyAsInt(io_service_t& usbDevice, CFStringRef propertyName)
-    -> std::optional<T> {
+    requires std::is_integral_v<T>
+auto getPropertyAsInt(io_service_t& usbDevice, CFStringRef propertyName) -> std::optional<T> {
     uint64_t value = 0;
     if (auto res = (CFNumberRef
         )IORegistryEntryCreateCFProperty(usbDevice, propertyName, kCFAllocatorDefault, 0);
@@ -278,18 +277,21 @@ auto findStoragePah(io_object_t entry, int level) noexcept
 // Helper function to find all USB device children of a given device using IOKit registry
 static auto findUSBChildren(io_service_t parentDevice) noexcept -> std::vector<io_service_t> {
     std::vector<io_service_t> children;
-    
+
     io_iterator_t childIterator;
-    if (IORegistryEntryGetChildIterator(parentDevice, kIOServicePlane, &childIterator) != KERN_SUCCESS) {
+    if (IORegistryEntryGetChildIterator(parentDevice, kIOServicePlane, &childIterator)
+        != KERN_SUCCESS)
+    {
         return children;
     }
-    
+
     io_service_t child;
     while ((child = IOIteratorNext(childIterator))) {
         // Check if this child is a USB device
         io_name_t className;
         if (IOObjectGetClass(child, className) == KERN_SUCCESS) {
-            if (strcmp(className, "IOUSBDevice") == 0 || strcmp(className, "IOUSBHostDevice") == 0) {
+            if (strcmp(className, "IOUSBDevice") == 0 || strcmp(className, "IOUSBHostDevice") == 0)
+            {
                 children.push_back(child);
                 // Don't release here - caller will release
             } else {
@@ -302,18 +304,17 @@ static auto findUSBChildren(io_service_t parentDevice) noexcept -> std::vector<i
             IOObjectRelease(child);
         }
     }
-    
+
     IOObjectRelease(childIterator);
     return children;
 }
 
-static auto _find_all_fw_classic() noexcept
-    -> std::expected<Fw::FreeWiliDevices, std::string> {
+static auto _find_all_fw_classic() noexcept -> std::expected<Fw::FreeWiliDevices, std::string> {
     CFMutableDictionaryRef matchingDict;
     if (matchingDict = IOServiceMatching(kIOUSBDeviceClassName); !matchingDict) {
         return std::unexpected("IOServiceMatching() Failure");
     }
-    
+
     io_iterator_t iter;
     if (auto res = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDict, &iter);
         res != KERN_SUCCESS)
@@ -325,87 +326,110 @@ static auto _find_all_fw_classic() noexcept
 
     std::vector<std::vector<Fw::USBDevice>> hubGroups;
     io_service_t usbDevice;
-    
+
     // Find all FreeWili hubs first
     while ((usbDevice = IOIteratorNext(iter))) {
         uint16_t vid = 0;
-        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idVendor")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idVendor"));
+            result.has_value())
+        {
             vid = result.value();
         }
         uint16_t pid = 0;
-        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idProduct")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idProduct"));
+            result.has_value())
+        {
             pid = result.value();
         }
-        
+
         // Only process FreeWili hubs
         if (vid != Fw::USB_VID_FW_HUB || pid != Fw::USB_PID_FW_HUB) {
             IOObjectRelease(usbDevice);
             continue;
         }
-        
+
         uint32_t addr = 0;
-        if (auto result = getPropertyAsInt<uint32_t>(usbDevice, CFSTR("locationID")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint32_t>(usbDevice, CFSTR("locationID"));
+            result.has_value())
+        {
             addr = result.value();
         }
 
         std::string manuName;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Vendor Name")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Vendor Name")); result.has_value())
+        {
             manuName = result.value();
         }
         std::string productName;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Product Name")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Product Name"));
+            result.has_value())
+        {
             productName = result.value();
         }
         std::string serial;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Serial Number")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Serial Number"));
+            result.has_value())
+        {
             serial = result.value();
         }
         // Create the hub device
-        Fw::USBDevice hubDevice {
-            .kind = Fw::USBDeviceType::Hub,
-            .vid = vid,
-            .pid = pid,
-            .name = manuName + " " + productName,
-            .serial = serial,
-            .location = getUSBPortFromLocationID(addr),
-            .portChain = getUSBPortChainFromLocationID(addr),
-            .paths = std::nullopt,
-            .port = std::nullopt,
-            ._raw = ""
-        };
+        Fw::USBDevice hubDevice { .kind = Fw::USBDeviceType::Hub,
+                                  .vid = vid,
+                                  .pid = pid,
+                                  .name = manuName + " " + productName,
+                                  .serial = serial,
+                                  .location = getUSBPortFromLocationID(addr),
+                                  .portChain = getUSBPortChainFromLocationID(addr),
+                                  .paths = std::nullopt,
+                                  .port = std::nullopt,
+                                  ._raw = "" };
 
         std::vector<Fw::USBDevice> hubGroup;
         hubGroup.push_back(hubDevice);
 
         // Find all children of this hub using IOKit registry
         auto children = findUSBChildren(usbDevice);
-        for (auto childDevice : children) {
+        for (auto childDevice: children) {
             uint16_t childVid = 0;
-            if (auto result = getPropertyAsInt<uint16_t>(childDevice, CFSTR("idVendor")); result.has_value()) {
+            if (auto result = getPropertyAsInt<uint16_t>(childDevice, CFSTR("idVendor"));
+                result.has_value())
+            {
                 childVid = result.value();
             }
             uint16_t childPid = 0;
-            if (auto result = getPropertyAsInt<uint16_t>(childDevice, CFSTR("idProduct")); result.has_value()) {
+            if (auto result = getPropertyAsInt<uint16_t>(childDevice, CFSTR("idProduct"));
+                result.has_value())
+            {
                 childPid = result.value();
             }
-            
+
             // Only include whitelisted, non-standalone children
-            if (Fw::is_vid_pid_whitelisted(childVid, childPid) && !Fw::isStandAloneDevice(childVid, childPid)) {
+            if (Fw::is_vid_pid_whitelisted(childVid, childPid)
+                && !Fw::isStandAloneDevice(childVid, childPid))
+            {
                 uint32_t childAddr = 0;
-                if (auto result = getPropertyAsInt<uint32_t>(childDevice, CFSTR("locationID")); result.has_value()) {
+                if (auto result = getPropertyAsInt<uint32_t>(childDevice, CFSTR("locationID"));
+                    result.has_value())
+                {
                     childAddr = result.value();
                 }
 
                 std::string childManuName;
-                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Vendor Name")); result.has_value()) {
+                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Vendor Name"));
+                    result.has_value())
+                {
                     childManuName = result.value();
                 }
                 std::string childProductName;
-                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Product Name")); result.has_value()) {
+                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Product Name"));
+                    result.has_value())
+                {
                     childProductName = result.value();
                 }
                 std::string childSerial;
-                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Serial Number")); result.has_value()) {
+                if (auto result = getPropertyAsStr(childDevice, CFSTR("USB Serial Number"));
+                    result.has_value())
+                {
                     childSerial = result.value();
                 }
 
@@ -450,7 +474,7 @@ static auto _find_all_fw_classic() noexcept
 
     // Convert hub groups to FreeWiliDevices
     Fw::FreeWiliDevices fwDevices;
-    for (auto&& devices : hubGroups) {
+    for (auto&& devices: hubGroups) {
         if (auto result = Fw::FreeWiliDevice::fromUSBDevices(devices); result.has_value()) {
             fwDevices.push_back(result.value());
         }
@@ -464,7 +488,7 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
     if (matchingDict = IOServiceMatching(kIOUSBDeviceClassName); !matchingDict) {
         return std::unexpected("IOServiceMatching() Failure");
     }
-    
+
     io_iterator_t iter;
     if (auto res = IOServiceGetMatchingServices(kIOMainPortDefault, matchingDict, &iter);
         res != KERN_SUCCESS)
@@ -476,14 +500,18 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
 
     std::map<std::string, std::vector<Fw::USBDevice>> standaloneDevices;
     io_service_t usbDevice;
-    
+
     while ((usbDevice = IOIteratorNext(iter))) {
         uint16_t vid = 0;
-        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idVendor")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idVendor"));
+            result.has_value())
+        {
             vid = result.value();
         }
         uint16_t pid = 0;
-        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idProduct")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint16_t>(usbDevice, CFSTR("idProduct"));
+            result.has_value())
+        {
             pid = result.value();
         }
 
@@ -494,23 +522,31 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
         }
 
         uint32_t addr = 0;
-        if (auto result = getPropertyAsInt<uint32_t>(usbDevice, CFSTR("locationID")); result.has_value()) {
+        if (auto result = getPropertyAsInt<uint32_t>(usbDevice, CFSTR("locationID"));
+            result.has_value())
+        {
             addr = result.value();
         }
         std::string containerId;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("kUSBContainerID")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("kUSBContainerID")); result.has_value())
+        {
             containerId = result.value();
         }
         std::string manuName;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Vendor Name")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Vendor Name")); result.has_value())
+        {
             manuName = result.value();
         }
         std::string productName;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Product Name")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Product Name"));
+            result.has_value())
+        {
             productName = result.value();
         }
         std::string serial;
-        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Serial Number")); result.has_value()) {
+        if (auto result = getPropertyAsStr(usbDevice, CFSTR("USB Serial Number"));
+            result.has_value())
+        {
             serial = result.value();
         }
 
@@ -528,20 +564,22 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
 
         // For standalone devices, use a unique key that includes the serial number
         // to ensure each device gets its own entry instead of being grouped together
-        std::string deviceKey = containerId + "_" + serial + "_" + std::to_string(vid) + "_" + std::to_string(pid);
+        std::string deviceKey =
+            containerId + "_" + serial + "_" + std::to_string(vid) + "_" + std::to_string(pid);
 
-        standaloneDevices[deviceKey].push_back(Fw::USBDevice { 
-            .kind = Fw::getUSBDeviceTypeFrom(vid, pid),
-            .vid = vid,
-            .pid = pid,
-            .name = manuName + " " + productName,
-            .serial = serial,
-            .location = getUSBPortFromLocationID(addr),
-            .portChain = getUSBPortChainFromLocationID(addr),
-            .paths = storagePaths.empty() ? std::nullopt : std::make_optional(storagePaths),
-            .port = serialPort,
-            ._raw = "" 
-        });
+        standaloneDevices[deviceKey].push_back(
+            Fw::USBDevice { .kind = Fw::getUSBDeviceTypeFrom(vid, pid),
+                            .vid = vid,
+                            .pid = pid,
+                            .name = manuName + " " + productName,
+                            .serial = serial,
+                            .location = getUSBPortFromLocationID(addr),
+                            .portChain = getUSBPortChainFromLocationID(addr),
+                            .paths = storagePaths.empty() ? std::nullopt
+                                                          : std::make_optional(storagePaths),
+                            .port = serialPort,
+                            ._raw = "" }
+        );
 
         IOObjectRelease(usbDevice);
     }
@@ -550,7 +588,7 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
 
     // Create FreeWiliDevice instances for each standalone device found
     Fw::FreeWiliDevices fwDevices;
-    for (auto&& [deviceKey, devices] : standaloneDevices) {
+    for (auto&& [deviceKey, devices]: standaloneDevices) {
         if (auto result = Fw::FreeWiliDevice::fromUSBDevices(devices); result.has_value()) {
             fwDevices.push_back(result.value());
         }
@@ -560,23 +598,32 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
 }
 
 auto Fw::find_all() noexcept -> std::expected<Fw::FreeWiliDevices, std::string> {
-    Fw::FreeWiliDevices allDevices;
+    Fw::FreeWiliDevices devices;
 
     // First, find all classic FreeWili devices (hub-based)
     if (auto classicResult = _find_all_fw_classic(); classicResult.has_value()) {
-        for (auto&& device : classicResult.value()) {
-            allDevices.push_back(device);
+        for (auto&& device: classicResult.value()) {
+            devices.push_back(device);
         }
     }
 
     // Then, find all standalone devices (badges)
     if (auto standaloneResult = _find_all_standalone(); standaloneResult.has_value()) {
-        for (auto&& device : standaloneResult.value()) {
-            allDevices.push_back(device);
+        for (auto&& device: standaloneResult.value()) {
+            devices.push_back(device);
         }
     }
 
-    return allDevices;
+    // Sort the devices by unique ID
+    std::sort(
+        devices.begin(),
+        devices.end(),
+        [](const Fw::FreeWiliDevice& lhs, const Fw::FreeWiliDevice& rhs) {
+            // order smallest to largest
+            return lhs.uniqueID < rhs.uniqueID;
+        }
+    );
+    return devices;
 }
 
 // NOLINTEND

--- a/src/fwfinder_windows.cpp
+++ b/src/fwfinder_windows.cpp
@@ -274,14 +274,7 @@ auto _getDevicePropertyMultiSz(DEVINST devInst, const DEVPROPKEY key) noexcept
         return std::unexpected(ss.str());
     }
     std::vector<BYTE> buffer(size + sizeof(TCHAR));
-    if (auto res = CM_Get_DevNode_Property(
-            devInst,
-            &key,
-            &propertyType,
-            buffer.data(),
-            &size,
-            0
-        );
+    if (auto res = CM_Get_DevNode_Property(devInst, &key, &propertyType, buffer.data(), &size, 0);
         res != CR_SUCCESS)
     {
         std::stringstream ss;
@@ -447,7 +440,7 @@ struct EnumeratedDevice {
     // Packed location derived from parsed USB port chain (up to 4 levels, 1 byte each).
     // If fewer than 4 levels, remaining bytes are 0. Root-most port is stored in the most
     // significant byte to keep lexical ordering by depth.
-    uint32_t location {0};
+    uint32_t location { 0 };
     uint16_t vid;
     uint16_t pid;
     std::string serial;
@@ -604,10 +597,8 @@ auto getEnumeratedDevices() noexcept
             enumeratedDevice->containerId = result.value();
         }
         // Location Paths -> Port Chain
-        if (auto locPaths = _getDevicePropertyMultiSz(
-                devInfoData.DevInst,
-                DEVPKEY_Device_LocationPaths
-            );
+        if (auto locPaths =
+                _getDevicePropertyMultiSz(devInfoData.DevInst, DEVPKEY_Device_LocationPaths);
             locPaths.has_value())
         {
             auto chain = _extractUSBPortChainFromLocationPaths(locPaths.value());
@@ -861,8 +852,6 @@ auto getHubEnumeratedDevices(
         // This grabs all VID/PID devices we care about for now.
         auto usbInstId = getUSBInstanceID(instanceId);
         if (!usbInstId.has_value()) {
-            // TODO
-            //std::println("\t\tInvalid VID/PID: {} {}", usbInstId.error(), instanceID);
             continue;
         } else if (!Fw::is_vid_pid_whitelisted(usbInstId.value().vid, usbInstId.value().pid)) {
             continue;
@@ -1013,14 +1002,11 @@ auto getHubEnumeratedDevices(
                             "Failed to get enumeratedDevice by driver key. Value is null"
                         );
                     }
-                    //enumeratedDevice->driverKey = name;
                     if (auto serialPort =
                             findSerialPort(allDeviceInfo, enumeratedDevice, devicesByInstanceId, 0);
                         serialPort.has_value())
                     {
                         enumeratedDevice->port = serialPort.value();
-                    } else {
-                        // TODO: std::cerr << serialPort.error();
                     }
                     if (auto volumePaths = findVolumePaths(
                             allDeviceInfo,
@@ -1033,8 +1019,6 @@ auto getHubEnumeratedDevices(
                         volumePaths.has_value())
                     {
                         enumeratedDevice->driveLetters = volumePaths.value();
-                    } else {
-                        // TODO: std::cerr << serialPort.error();
                     }
 
                     enumeratedDevice->location = i;
@@ -1088,8 +1072,8 @@ auto _find_all_freewili() noexcept -> std::expected<Fw::FreeWiliDevices, std::st
                 .name = hub.first->busDescription + " (" + hub.first->description + ")",
                 .serial = hub.first->serial,
                 .location = hub.first->location,
-                .paths = std::nullopt, // TODO
-                .port = "", // TODO
+                .paths = std::nullopt,
+                .port = "",
                 ._raw = hub.first->instanceId,
             }
         );
@@ -1102,7 +1086,7 @@ auto _find_all_freewili() noexcept -> std::expected<Fw::FreeWiliDevices, std::st
                     .name = child->busDescription + " (" + child->description + ")",
                     .serial = child->serial,
                     .location = child->location,
-                    .paths = child->driveLetters, // TODO
+                    .paths = child->driveLetters,
                     .port = child->port,
                     ._raw = child->instanceId,
                 }
@@ -1184,7 +1168,7 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
                 .name = device.second->busDescription + " (" + device.second->description + ")",
                 .serial = device.second->serial,
                 .location = device.second->location,
-                .paths = device.second->driveLetters, // TODO
+                .paths = device.second->driveLetters,
                 .port = device.second->port,
                 ._raw = device.second->instanceId,
             }
@@ -1193,7 +1177,6 @@ auto _find_all_standalone() noexcept -> std::expected<Fw::FreeWiliDevices, std::
             fwDevices.push_back(result.value());
         } else {
             return std::unexpected(result.error());
-            // TODO
         }
     }
     // Sort the devices by serial number

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -44,11 +44,11 @@ TEST(FwFinder, getUSBDeviceTypeName) {
 
 TEST(FwFinder, getDeviceTypeName) {
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::Unknown).c_str(), "Unknown");
-    ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::FreeWili).c_str(), "FreeWili");
-    ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge).c_str(), "DefCon2024Badge");
+    ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::FreeWili).c_str(), "Free-WiLi");
+    ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge).c_str(), "DefCon 2024 Badge");
     ASSERT_STREQ(
         Fw::getDeviceTypeName(Fw::DeviceType::DefCon2025FwBadge).c_str(),
-        "DefCon2025FwBadge"
+        "DefCon 2025 Badge"
     );
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::UF2).c_str(), "UF2");
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::Winky).c_str(), "Winky");
@@ -108,4 +108,57 @@ TEST(FwFinder, isStandAloneDevice) {
     ASSERT_FALSE(Fw::isStandAloneDevice(Fw::USB_VID_FW_ICS, Fw::USB_PID_FW_DISPLAY_CDC_PID));
 
     ASSERT_FALSE(Fw::isStandAloneDevice(0, 0));
+}
+
+TEST(FwFinder, generateUniqueID) {
+    // Test basic functionality - parent location in upper 32 bits, device location in lower 32 bits
+    uint64_t uniqueId = Fw::generateUniqueID(0x12345678, 0x9ABCDEF0);
+    uint64_t expected = (static_cast<uint64_t>(0x12345678) << 32) | 0x9ABCDEF0;
+    ASSERT_EQ(uniqueId, expected);
+    ASSERT_EQ(uniqueId, 0x123456789ABCDEF0ULL);
+
+    // Test with zero values
+    ASSERT_EQ(Fw::generateUniqueID(0, 0), 0ULL);
+    
+    // Test with zero parent location
+    ASSERT_EQ(Fw::generateUniqueID(0, 5), 5ULL);
+    
+    // Test with zero device location
+    ASSERT_EQ(Fw::generateUniqueID(3, 0), 0x0000000300000000ULL);
+
+    // Test with small values
+    ASSERT_EQ(Fw::generateUniqueID(1, 2), 0x0000000100000002ULL);
+    ASSERT_EQ(Fw::generateUniqueID(2, 5), 0x0000000200000005ULL);
+
+    // Test with maximum 32-bit values
+    ASSERT_EQ(
+        Fw::generateUniqueID(0xFFFFFFFF, 0xFFFFFFFF), 
+        0xFFFFFFFFFFFFFFFFULL
+    );
+
+    // Test that parent and device locations are properly separated
+    uint64_t id1 = Fw::generateUniqueID(1, 0);
+    uint64_t id2 = Fw::generateUniqueID(0, 1);
+    ASSERT_NE(id1, id2);
+    ASSERT_EQ(id1, 0x0000000100000000ULL);
+    ASSERT_EQ(id2, 0x0000000000000001ULL);
+
+    // Test ordering - verify that higher parent locations result in higher unique IDs
+    ASSERT_LT(Fw::generateUniqueID(1, 5), Fw::generateUniqueID(2, 1));
+    ASSERT_LT(Fw::generateUniqueID(5, 10), Fw::generateUniqueID(6, 1));
+
+    // Test that device location affects ordering within same parent
+    ASSERT_LT(Fw::generateUniqueID(1, 1), Fw::generateUniqueID(1, 2));
+    ASSERT_LT(Fw::generateUniqueID(10, 5), Fw::generateUniqueID(10, 6));
+
+    // Test bit extraction - verify we can extract parent and device locations
+    uint32_t parentLocation = 0x12345678;
+    uint32_t deviceLocation = 0x9ABCDEF0;
+    uint64_t combinedId = Fw::generateUniqueID(parentLocation, deviceLocation);
+    
+    uint32_t extractedParent = static_cast<uint32_t>(combinedId >> 32);
+    uint32_t extractedDevice = static_cast<uint32_t>(combinedId & 0xFFFFFFFF);
+    
+    ASSERT_EQ(extractedParent, parentLocation);
+    ASSERT_EQ(extractedDevice, deviceLocation);
 }

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -114,56 +114,6 @@ TEST(FwFinder, isStandAloneDevice) {
     ASSERT_FALSE(Fw::isStandAloneDevice(0, 0));
 }
 
-TEST(FwFinder, generateUniqueID) {
-    // Test basic functionality - parent location in upper 32 bits, device location in lower 32 bits
-    uint64_t uniqueId = Fw::generateUniqueID(0x12345678, 0x9ABCDEF0);
-    uint64_t expected = (static_cast<uint64_t>(0x12345678) << 32) | 0x9ABCDEF0;
-    ASSERT_EQ(uniqueId, expected);
-    ASSERT_EQ(uniqueId, 0x123456789ABCDEF0ULL);
-
-    // Test with zero values
-    ASSERT_EQ(Fw::generateUniqueID(0, 0), 0ULL);
-
-    // Test with zero parent location
-    ASSERT_EQ(Fw::generateUniqueID(0, 5), 5ULL);
-
-    // Test with zero device location
-    ASSERT_EQ(Fw::generateUniqueID(3, 0), 0x0000000300000000ULL);
-
-    // Test with small values
-    ASSERT_EQ(Fw::generateUniqueID(1, 2), 0x0000000100000002ULL);
-    ASSERT_EQ(Fw::generateUniqueID(2, 5), 0x0000000200000005ULL);
-
-    // Test with maximum 32-bit values
-    ASSERT_EQ(Fw::generateUniqueID(0xFFFFFFFF, 0xFFFFFFFF), 0xFFFFFFFFFFFFFFFFULL);
-
-    // Test that parent and device locations are properly separated
-    uint64_t id1 = Fw::generateUniqueID(1, 0);
-    uint64_t id2 = Fw::generateUniqueID(0, 1);
-    ASSERT_NE(id1, id2);
-    ASSERT_EQ(id1, 0x0000000100000000ULL);
-    ASSERT_EQ(id2, 0x0000000000000001ULL);
-
-    // Test ordering - verify that higher parent locations result in higher unique IDs
-    ASSERT_LT(Fw::generateUniqueID(1, 5), Fw::generateUniqueID(2, 1));
-    ASSERT_LT(Fw::generateUniqueID(5, 10), Fw::generateUniqueID(6, 1));
-
-    // Test that device location affects ordering within same parent
-    ASSERT_LT(Fw::generateUniqueID(1, 1), Fw::generateUniqueID(1, 2));
-    ASSERT_LT(Fw::generateUniqueID(10, 5), Fw::generateUniqueID(10, 6));
-
-    // Test bit extraction - verify we can extract parent and device locations
-    uint32_t parentLocation = 0x12345678;
-    uint32_t deviceLocation = 0x9ABCDEF0;
-    uint64_t combinedId = Fw::generateUniqueID(parentLocation, deviceLocation);
-
-    uint32_t extractedParent = static_cast<uint32_t>(combinedId >> 32);
-    uint32_t extractedDevice = static_cast<uint32_t>(combinedId & 0xFFFFFFFF);
-
-    ASSERT_EQ(extractedParent, parentLocation);
-    ASSERT_EQ(extractedDevice, deviceLocation);
-}
-
 /**
  * @brief Test fixture class for creating various FreeWiliDevice configurations
  *
@@ -275,7 +225,7 @@ public:
             .setDeviceType(Fw::DeviceType::FreeWili)
             .setName("Test FreeWili with Serials")
             .setSerial("FTDI001") // Use FTDI serial as device serial
-            .setUniqueID(Fw::generateUniqueID(1, 1))
+            .setUniqueID(1)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -293,7 +243,7 @@ public:
             .setDeviceType(Fw::DeviceType::FreeWili)
             .setName("Test FreeWili with Mass Storage")
             .setSerial("FTDI001")
-            .setUniqueID(Fw::generateUniqueID(1, 2))
+            .setUniqueID(2)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -310,7 +260,7 @@ public:
             .setDeviceType(Fw::DeviceType::FreeWili)
             .setName("Test FreeWili without FTDI - Mass Storage")
             .setSerial("HUB001") // Use Hub serial since no FTDI
-            .setUniqueID(Fw::generateUniqueID(1, 3))
+            .setUniqueID(3)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -327,7 +277,7 @@ public:
             .setDeviceType(Fw::DeviceType::FreeWili)
             .setName("Test FreeWili without FTDI - Serials")
             .setSerial("HUB001") // Use Hub serial since no FTDI
-            .setUniqueID(Fw::generateUniqueID(1, 4))
+            .setUniqueID(4)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -342,7 +292,7 @@ public:
             .setDeviceType(Fw::DeviceType::FreeWili)
             .setName("Test Minimal FreeWili")
             .setSerial("FTDI001")
-            .setUniqueID(Fw::generateUniqueID(1, 5))
+            .setUniqueID(5)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -47,12 +47,12 @@ TEST(FwFinder, getDeviceTypeName) {
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::Unknown).c_str(), "Unknown");
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::FreeWili).c_str(), "Free-WiLi");
     ASSERT_STREQ(
-        Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge).c_str(),
-        "DefCon 2024 Badge"
+        Fw::getDeviceTypeName(Fw::DeviceType::DEFCON2024Badge).c_str(),
+        "DEFCON 2024 Badge"
     );
     ASSERT_STREQ(
-        Fw::getDeviceTypeName(Fw::DeviceType::DefCon2025FwBadge).c_str(),
-        "DefCon 2025 Badge"
+        Fw::getDeviceTypeName(Fw::DeviceType::DEFCON2025FwBadge).c_str(),
+        "DEFCON 2025 Badge"
     );
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::UF2).c_str(), "UF2");
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::Winky).c_str(), "Winky");
@@ -166,7 +166,7 @@ TEST(FwFinder, generateUniqueID) {
 
 /**
  * @brief Test fixture class for creating various FreeWiliDevice configurations
- * 
+ *
  * This class provides factory methods to create FreeWiliDevice instances with
  * different USB device configurations for comprehensive testing.
  */

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -131,7 +131,8 @@ public:
                                .pid = Fw::USB_PID_FW_HUB,
                                .name = "Free-WiLi Hub",
                                .serial = "HUB001",
-                               .location = 0, // Hub is at the root level, not on a specific port
+                               .location = 3, // Hub is at the root level, not on a specific port
+                               .portChain = { 1, 2, 3 },
                                .paths = std::nullopt,
                                .port = std::nullopt,
                                ._raw = "/sys/devices/hub" };
@@ -146,7 +147,8 @@ public:
                                .pid = Fw::USB_PID_FW_FTDI,
                                .name = "Free-WiLi FTDI",
                                .serial = "FTDI001",
-                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA),
+                               .location = 3,
+                               .portChain = { 1, 2, 3 },
                                .paths = std::nullopt,
                                .port = std::nullopt,
                                ._raw = "/sys/devices/ftdi" };
@@ -161,7 +163,8 @@ public:
                                .pid = Fw::USB_PID_FW_MAIN_CDC_PID,
                                .name = "Free-WiLi Main Serial",
                                .serial = "MAIN001",
-                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Main),
+                               .location = 1,
+                               .portChain = { 1, 2, 1 },
                                .paths = std::nullopt,
                                .port = std::string("/dev/ttyACM0"),
                                ._raw = "/sys/devices/main_serial" };
@@ -176,7 +179,8 @@ public:
                                .pid = Fw::USB_PID_FW_DISPLAY_CDC_PID,
                                .name = "Free-WiLi Display Serial",
                                .serial = "DISP001",
-                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Display),
+                               .location = 2,
+                               .portChain = { 1, 2, 2 },
                                .paths = std::nullopt,
                                .port = std::string("/dev/ttyACM1"),
                                ._raw = "/sys/devices/display_serial" };
@@ -191,7 +195,8 @@ public:
                                .pid = Fw::USB_PID_FW_RPI_2040_UF2_PID,
                                .name = "Free-WiLi Main Storage",
                                .serial = "MASS001",
-                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Main),
+                               .location = 1,
+                               .portChain = { 1, 2, 1 },
                                .paths = std::vector<std::string> { "/mnt/freewili_main" },
                                .port = std::nullopt,
                                ._raw = "/sys/devices/main_storage" };
@@ -206,7 +211,8 @@ public:
                                .pid = Fw::USB_PID_FW_RPI_2040_UF2_PID,
                                .name = "Free-WiLi Display Storage",
                                .serial = "MASS002",
-                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Display),
+                               .location = 2,
+                               .portChain = { 1, 2, 2 },
                                .paths = std::vector<std::string> { "/mnt/freewili_display" },
                                .port = std::nullopt,
                                ._raw = "/sys/devices/display_storage" };

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <fwfinder.hpp>
+#include <fwbuilder.hpp>
 #include <usbdef.hpp>
 
 #include <cstdio>
@@ -45,7 +46,10 @@ TEST(FwFinder, getUSBDeviceTypeName) {
 TEST(FwFinder, getDeviceTypeName) {
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::Unknown).c_str(), "Unknown");
     ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::FreeWili).c_str(), "Free-WiLi");
-    ASSERT_STREQ(Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge).c_str(), "DefCon 2024 Badge");
+    ASSERT_STREQ(
+        Fw::getDeviceTypeName(Fw::DeviceType::DefCon2024Badge).c_str(),
+        "DefCon 2024 Badge"
+    );
     ASSERT_STREQ(
         Fw::getDeviceTypeName(Fw::DeviceType::DefCon2025FwBadge).c_str(),
         "DefCon 2025 Badge"
@@ -119,10 +123,10 @@ TEST(FwFinder, generateUniqueID) {
 
     // Test with zero values
     ASSERT_EQ(Fw::generateUniqueID(0, 0), 0ULL);
-    
+
     // Test with zero parent location
     ASSERT_EQ(Fw::generateUniqueID(0, 5), 5ULL);
-    
+
     // Test with zero device location
     ASSERT_EQ(Fw::generateUniqueID(3, 0), 0x0000000300000000ULL);
 
@@ -131,10 +135,7 @@ TEST(FwFinder, generateUniqueID) {
     ASSERT_EQ(Fw::generateUniqueID(2, 5), 0x0000000200000005ULL);
 
     // Test with maximum 32-bit values
-    ASSERT_EQ(
-        Fw::generateUniqueID(0xFFFFFFFF, 0xFFFFFFFF), 
-        0xFFFFFFFFFFFFFFFFULL
-    );
+    ASSERT_EQ(Fw::generateUniqueID(0xFFFFFFFF, 0xFFFFFFFF), 0xFFFFFFFFFFFFFFFFULL);
 
     // Test that parent and device locations are properly separated
     uint64_t id1 = Fw::generateUniqueID(1, 0);
@@ -155,10 +156,390 @@ TEST(FwFinder, generateUniqueID) {
     uint32_t parentLocation = 0x12345678;
     uint32_t deviceLocation = 0x9ABCDEF0;
     uint64_t combinedId = Fw::generateUniqueID(parentLocation, deviceLocation);
-    
+
     uint32_t extractedParent = static_cast<uint32_t>(combinedId >> 32);
     uint32_t extractedDevice = static_cast<uint32_t>(combinedId & 0xFFFFFFFF);
-    
+
     ASSERT_EQ(extractedParent, parentLocation);
     ASSERT_EQ(extractedDevice, deviceLocation);
+}
+
+/**
+ * @brief Test fixture class for creating various FreeWiliDevice configurations
+ * 
+ * This class provides factory methods to create FreeWiliDevice instances with
+ * different USB device configurations for comprehensive testing.
+ */
+class FreeWiliDeviceTestSetup {
+public:
+    /**
+     * @brief Creates a USB Hub device
+     */
+    static Fw::USBDevice createHubDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::Hub,
+                               .vid = Fw::USB_VID_FW_HUB,
+                               .pid = Fw::USB_PID_FW_HUB,
+                               .name = "Free-WiLi Hub",
+                               .serial = "HUB001",
+                               .location = 0, // Hub is at the root level, not on a specific port
+                               .paths = std::nullopt,
+                               .port = std::nullopt,
+                               ._raw = "/sys/devices/hub" };
+    }
+
+    /**
+     * @brief Creates an FTDI device (FPGA)
+     */
+    static Fw::USBDevice createFTDIDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::FTDI,
+                               .vid = Fw::USB_VID_FW_FTDI,
+                               .pid = Fw::USB_PID_FW_FTDI,
+                               .name = "Free-WiLi FTDI",
+                               .serial = "FTDI001",
+                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA),
+                               .paths = std::nullopt,
+                               .port = std::nullopt,
+                               ._raw = "/sys/devices/ftdi" };
+    }
+
+    /**
+     * @brief Creates a Main Serial device
+     */
+    static Fw::USBDevice createMainSerialDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::SerialMain,
+                               .vid = Fw::USB_VID_FW_ICS,
+                               .pid = Fw::USB_PID_FW_MAIN_CDC_PID,
+                               .name = "Free-WiLi Main Serial",
+                               .serial = "MAIN001",
+                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Main),
+                               .paths = std::nullopt,
+                               .port = std::string("/dev/ttyACM0"),
+                               ._raw = "/sys/devices/main_serial" };
+    }
+
+    /**
+     * @brief Creates a Display Serial device
+     */
+    static Fw::USBDevice createDisplaySerialDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::SerialDisplay,
+                               .vid = Fw::USB_VID_FW_ICS,
+                               .pid = Fw::USB_PID_FW_DISPLAY_CDC_PID,
+                               .name = "Free-WiLi Display Serial",
+                               .serial = "DISP001",
+                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Display),
+                               .paths = std::nullopt,
+                               .port = std::string("/dev/ttyACM1"),
+                               ._raw = "/sys/devices/display_serial" };
+    }
+
+    /**
+     * @brief Creates a Main Mass Storage device
+     */
+    static Fw::USBDevice createMainMassStorageDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::MassStorage,
+                               .vid = Fw::USB_VID_FW_RPI,
+                               .pid = Fw::USB_PID_FW_RPI_2040_UF2_PID,
+                               .name = "Free-WiLi Main Storage",
+                               .serial = "MASS001",
+                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Main),
+                               .paths = std::vector<std::string> { "/mnt/freewili_main" },
+                               .port = std::nullopt,
+                               ._raw = "/sys/devices/main_storage" };
+    }
+
+    /**
+     * @brief Creates a Display Mass Storage device
+     */
+    static Fw::USBDevice createDisplayMassStorageDevice() {
+        return Fw::USBDevice { .kind = Fw::USBDeviceType::MassStorage,
+                               .vid = Fw::USB_VID_FW_RPI,
+                               .pid = Fw::USB_PID_FW_RPI_2040_UF2_PID,
+                               .name = "Free-WiLi Display Storage",
+                               .serial = "MASS002",
+                               .location = static_cast<uint32_t>(Fw::USBHubPortLocation::Display),
+                               .paths = std::vector<std::string> { "/mnt/freewili_display" },
+                               .port = std::nullopt,
+                               ._raw = "/sys/devices/display_storage" };
+    }
+
+    /**
+     * @brief Creates a FreeWiliDevice with Hub, FTDI, and Serial devices
+     */
+    static std::expected<Fw::FreeWiliDevice, std::string> createDeviceWithSerials() {
+        Fw::USBDevices usbDevices = { createHubDevice(),
+                                      createFTDIDevice(),
+                                      createMainSerialDevice(),
+                                      createDisplaySerialDevice() };
+
+        return Fw::FreeWiliDevice::builder()
+            .setDeviceType(Fw::DeviceType::FreeWili)
+            .setName("Test FreeWili with Serials")
+            .setSerial("FTDI001") // Use FTDI serial as device serial
+            .setUniqueID(Fw::generateUniqueID(1, 1))
+            .setUSBDevices(std::move(usbDevices))
+            .build();
+    }
+
+    /**
+     * @brief Creates a FreeWiliDevice with Hub, FTDI, and Mass Storage devices
+     */
+    static std::expected<Fw::FreeWiliDevice, std::string> createDeviceWithMassStorage() {
+        Fw::USBDevices usbDevices = { createHubDevice(),
+                                      createFTDIDevice(),
+                                      createMainMassStorageDevice(),
+                                      createDisplayMassStorageDevice() };
+
+        return Fw::FreeWiliDevice::builder()
+            .setDeviceType(Fw::DeviceType::FreeWili)
+            .setName("Test FreeWili with Mass Storage")
+            .setSerial("FTDI001")
+            .setUniqueID(Fw::generateUniqueID(1, 2))
+            .setUSBDevices(std::move(usbDevices))
+            .build();
+    }
+
+    /**
+     * @brief Creates a FreeWiliDevice missing FTDI with Mass Storage devices
+     */
+    static std::expected<Fw::FreeWiliDevice, std::string> createDeviceWithoutFTDIMassStorage() {
+        Fw::USBDevices usbDevices = { createHubDevice(),
+                                      createMainMassStorageDevice(),
+                                      createDisplayMassStorageDevice() };
+
+        return Fw::FreeWiliDevice::builder()
+            .setDeviceType(Fw::DeviceType::FreeWili)
+            .setName("Test FreeWili without FTDI - Mass Storage")
+            .setSerial("HUB001") // Use Hub serial since no FTDI
+            .setUniqueID(Fw::generateUniqueID(1, 3))
+            .setUSBDevices(std::move(usbDevices))
+            .build();
+    }
+
+    /**
+     * @brief Creates a FreeWiliDevice missing FTDI with Serial devices
+     */
+    static std::expected<Fw::FreeWiliDevice, std::string> createDeviceWithoutFTDISerials() {
+        Fw::USBDevices usbDevices = { createHubDevice(),
+                                      createMainSerialDevice(),
+                                      createDisplaySerialDevice() };
+
+        return Fw::FreeWiliDevice::builder()
+            .setDeviceType(Fw::DeviceType::FreeWili)
+            .setName("Test FreeWili without FTDI - Serials")
+            .setSerial("HUB001") // Use Hub serial since no FTDI
+            .setUniqueID(Fw::generateUniqueID(1, 4))
+            .setUSBDevices(std::move(usbDevices))
+            .build();
+    }
+
+    /**
+     * @brief Creates a minimal FreeWiliDevice with only Hub and FTDI
+     */
+    static std::expected<Fw::FreeWiliDevice, std::string> createMinimalDevice() {
+        Fw::USBDevices usbDevices = { createHubDevice(), createFTDIDevice() };
+
+        return Fw::FreeWiliDevice::builder()
+            .setDeviceType(Fw::DeviceType::FreeWili)
+            .setName("Test Minimal FreeWili")
+            .setSerial("FTDI001")
+            .setUniqueID(Fw::generateUniqueID(1, 5))
+            .setUSBDevices(std::move(usbDevices))
+            .build();
+    }
+};
+
+/**
+ * @brief Test fixture for FreeWiliDevice method testing
+ */
+class FreeWiliDeviceMethodTest: public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create all test devices
+        auto deviceWithSerials = FreeWiliDeviceTestSetup::createDeviceWithSerials();
+        ASSERT_TRUE(deviceWithSerials.has_value())
+            << "Failed to create device with serials: " << deviceWithSerials.error();
+        deviceWithSerials_ =
+            std::make_unique<Fw::FreeWiliDevice>(std::move(deviceWithSerials.value()));
+
+        auto deviceWithMassStorage = FreeWiliDeviceTestSetup::createDeviceWithMassStorage();
+        ASSERT_TRUE(deviceWithMassStorage.has_value())
+            << "Failed to create device with mass storage: " << deviceWithMassStorage.error();
+        deviceWithMassStorage_ =
+            std::make_unique<Fw::FreeWiliDevice>(std::move(deviceWithMassStorage.value()));
+
+        auto deviceWithoutFTDIMassStorage =
+            FreeWiliDeviceTestSetup::createDeviceWithoutFTDIMassStorage();
+        ASSERT_TRUE(deviceWithoutFTDIMassStorage.has_value())
+            << "Failed to create device without FTDI with mass storage: "
+            << deviceWithoutFTDIMassStorage.error();
+        deviceWithoutFTDIMassStorage_ =
+            std::make_unique<Fw::FreeWiliDevice>(std::move(deviceWithoutFTDIMassStorage.value()));
+
+        auto deviceWithoutFTDISerials = FreeWiliDeviceTestSetup::createDeviceWithoutFTDISerials();
+        ASSERT_TRUE(deviceWithoutFTDISerials.has_value())
+            << "Failed to create device without FTDI with serials: "
+            << deviceWithoutFTDISerials.error();
+        deviceWithoutFTDISerials_ =
+            std::make_unique<Fw::FreeWiliDevice>(std::move(deviceWithoutFTDISerials.value()));
+
+        auto minimalDevice = FreeWiliDeviceTestSetup::createMinimalDevice();
+        ASSERT_TRUE(minimalDevice.has_value())
+            << "Failed to create minimal device: " << minimalDevice.error();
+        minimalDevice_ = std::make_unique<Fw::FreeWiliDevice>(std::move(minimalDevice.value()));
+    }
+
+    std::unique_ptr<Fw::FreeWiliDevice> deviceWithSerials_;
+    std::unique_ptr<Fw::FreeWiliDevice> deviceWithMassStorage_;
+    std::unique_ptr<Fw::FreeWiliDevice> deviceWithoutFTDIMassStorage_;
+    std::unique_ptr<Fw::FreeWiliDevice> deviceWithoutFTDISerials_;
+    std::unique_ptr<Fw::FreeWiliDevice> minimalDevice_;
+};
+
+// Tests for getMainUSBDevice
+TEST_F(FreeWiliDeviceMethodTest, GetMainUSBDevice_WithSerials_ReturnsMainSerial) {
+    auto result = deviceWithSerials_->getMainUSBDevice();
+    ASSERT_TRUE(result.has_value()) << "Expected main USB device, got error: " << result.error();
+
+    const auto& device = result.value();
+    EXPECT_EQ(device.kind, Fw::USBDeviceType::SerialMain);
+    EXPECT_EQ(device.location, static_cast<uint32_t>(Fw::USBHubPortLocation::Main));
+    EXPECT_EQ(device.serial, "MAIN001");
+    EXPECT_TRUE(device.port.has_value());
+    EXPECT_EQ(device.port.value(), "/dev/ttyACM0");
+}
+
+TEST_F(FreeWiliDeviceMethodTest, GetMainUSBDevice_WithMassStorage_ReturnsMainMassStorage) {
+    auto result = deviceWithMassStorage_->getMainUSBDevice();
+    ASSERT_TRUE(result.has_value()) << "Expected main USB device, got error: " << result.error();
+
+    const auto& device = result.value();
+    EXPECT_EQ(device.kind, Fw::USBDeviceType::MassStorage);
+    EXPECT_EQ(device.location, static_cast<uint32_t>(Fw::USBHubPortLocation::Main));
+    EXPECT_EQ(device.serial, "MASS001");
+    EXPECT_TRUE(device.paths.has_value());
+    EXPECT_EQ(device.paths.value().size(), 1);
+    EXPECT_EQ(device.paths.value()[0], "/mnt/freewili_main");
+}
+
+TEST_F(FreeWiliDeviceMethodTest, GetMainUSBDevice_MinimalDevice_ReturnsError) {
+    auto result = minimalDevice_->getMainUSBDevice();
+    EXPECT_FALSE(result.has_value());
+    // Error message may vary - just check that it failed
+}
+
+// Tests for getDisplayUSBDevice
+TEST_F(FreeWiliDeviceMethodTest, GetDisplayUSBDevice_WithSerials_ReturnsDisplaySerial) {
+    auto result = deviceWithSerials_->getDisplayUSBDevice();
+    ASSERT_TRUE(result.has_value()) << "Expected display USB device, got error: " << result.error();
+
+    const auto& device = result.value();
+    EXPECT_EQ(device.kind, Fw::USBDeviceType::SerialDisplay);
+    EXPECT_EQ(device.location, static_cast<uint32_t>(Fw::USBHubPortLocation::Display));
+    EXPECT_EQ(device.serial, "DISP001");
+    EXPECT_TRUE(device.port.has_value());
+    EXPECT_EQ(device.port.value(), "/dev/ttyACM1");
+}
+
+TEST_F(FreeWiliDeviceMethodTest, GetDisplayUSBDevice_WithMassStorage_ReturnsDisplayMassStorage) {
+    auto result = deviceWithMassStorage_->getDisplayUSBDevice();
+    ASSERT_TRUE(result.has_value()) << "Expected display USB device, got error: " << result.error();
+
+    const auto& device = result.value();
+    EXPECT_EQ(device.kind, Fw::USBDeviceType::MassStorage);
+    EXPECT_EQ(device.location, static_cast<uint32_t>(Fw::USBHubPortLocation::Display));
+    EXPECT_EQ(device.serial, "MASS002");
+    EXPECT_TRUE(device.paths.has_value());
+    EXPECT_EQ(device.paths.value().size(), 1);
+    EXPECT_EQ(device.paths.value()[0], "/mnt/freewili_display");
+}
+
+TEST_F(FreeWiliDeviceMethodTest, GetDisplayUSBDevice_MinimalDevice_ReturnsError) {
+    auto result = minimalDevice_->getDisplayUSBDevice();
+    EXPECT_FALSE(result.has_value());
+    // Error message may vary - just check that it failed
+}
+
+// Tests for getHubUSBDevice
+TEST_F(FreeWiliDeviceMethodTest, GetHubUSBDevice_AllDevices_ReturnsHub) {
+    // Test all device configurations should have a hub
+    std::vector<std::unique_ptr<Fw::FreeWiliDevice>*> devices = { &deviceWithSerials_,
+                                                                  &deviceWithMassStorage_,
+                                                                  &deviceWithoutFTDIMassStorage_,
+                                                                  &deviceWithoutFTDISerials_,
+                                                                  &minimalDevice_ };
+
+    for (const auto& devicePtr: devices) {
+        auto result = (*devicePtr)->getHubUSBDevice();
+        ASSERT_TRUE(result.has_value()) << "Expected hub USB device, got error: " << result.error();
+
+        const auto& hubDevice = result.value();
+        EXPECT_EQ(hubDevice.kind, Fw::USBDeviceType::Hub);
+        EXPECT_EQ(hubDevice.vid, Fw::USB_VID_FW_HUB);
+        EXPECT_EQ(hubDevice.pid, Fw::USB_PID_FW_HUB);
+        EXPECT_EQ(hubDevice.serial, "HUB001");
+    }
+}
+
+// Tests for getFPGAUSBDevice (FTDI)
+TEST_F(FreeWiliDeviceMethodTest, GetFPGAUSBDevice_WithFTDI_ReturnsFTDI) {
+    std::vector<std::unique_ptr<Fw::FreeWiliDevice>*> devicesWithFTDI = { &deviceWithSerials_,
+                                                                          &deviceWithMassStorage_,
+                                                                          &minimalDevice_ };
+
+    for (const auto& devicePtr: devicesWithFTDI) {
+        auto result = (*devicePtr)->getFPGAUSBDevice();
+        ASSERT_TRUE(result.has_value())
+            << "Expected FPGA USB device, got error: " << result.error();
+
+        const auto& fpgaDevice = result.value();
+        EXPECT_EQ(fpgaDevice.kind, Fw::USBDeviceType::FTDI);
+        EXPECT_EQ(fpgaDevice.location, static_cast<uint32_t>(Fw::USBHubPortLocation::FPGA));
+        EXPECT_EQ(fpgaDevice.vid, Fw::USB_VID_FW_FTDI);
+        EXPECT_EQ(fpgaDevice.pid, Fw::USB_PID_FW_FTDI);
+        EXPECT_EQ(fpgaDevice.serial, "FTDI001");
+    }
+}
+
+TEST_F(FreeWiliDeviceMethodTest, GetFPGAUSBDevice_WithoutFTDI_ReturnsError) {
+    std::vector<std::unique_ptr<Fw::FreeWiliDevice>*> devicesWithoutFTDI = {
+        &deviceWithoutFTDIMassStorage_,
+        &deviceWithoutFTDISerials_
+    };
+
+    for (const auto& devicePtr: devicesWithoutFTDI) {
+        auto result = (*devicePtr)->getFPGAUSBDevice();
+        EXPECT_FALSE(result.has_value());
+        // The exact error message depends on the implementation
+    }
+}
+
+// Integration tests for device creation
+TEST(FreeWiliDeviceTestSetupTest, CreateAllDeviceTypes_Success) {
+    // Test that all device factory methods work
+    auto deviceWithSerials = FreeWiliDeviceTestSetup::createDeviceWithSerials();
+    EXPECT_TRUE(deviceWithSerials.has_value()) << deviceWithSerials.error();
+
+    auto deviceWithMassStorage = FreeWiliDeviceTestSetup::createDeviceWithMassStorage();
+    EXPECT_TRUE(deviceWithMassStorage.has_value()) << deviceWithMassStorage.error();
+
+    auto deviceWithoutFTDIMassStorage =
+        FreeWiliDeviceTestSetup::createDeviceWithoutFTDIMassStorage();
+    EXPECT_TRUE(deviceWithoutFTDIMassStorage.has_value()) << deviceWithoutFTDIMassStorage.error();
+
+    auto deviceWithoutFTDISerials = FreeWiliDeviceTestSetup::createDeviceWithoutFTDISerials();
+    EXPECT_TRUE(deviceWithoutFTDISerials.has_value()) << deviceWithoutFTDISerials.error();
+
+    auto minimalDevice = FreeWiliDeviceTestSetup::createMinimalDevice();
+    EXPECT_TRUE(minimalDevice.has_value()) << minimalDevice.error();
+}
+
+TEST(FreeWiliDeviceTestSetupTest, DeviceTypes_AreCorrect) {
+    auto device = FreeWiliDeviceTestSetup::createDeviceWithSerials();
+    ASSERT_TRUE(device.has_value());
+
+    EXPECT_EQ(device->deviceType, Fw::DeviceType::FreeWili);
+    EXPECT_FALSE(device->name.empty());
+    EXPECT_FALSE(device->serial.empty());
+    EXPECT_NE(device->uniqueID, std::numeric_limits<uint64_t>::max());
+    EXPECT_FALSE(device->usbDevices.empty());
 }

--- a/test/test_fwfinder.cpp
+++ b/test/test_fwfinder.cpp
@@ -232,6 +232,7 @@ public:
             .setName("Test FreeWili with Serials")
             .setSerial("FTDI001") // Use FTDI serial as device serial
             .setUniqueID(1)
+            .setStandalone(false)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -250,6 +251,7 @@ public:
             .setName("Test FreeWili with Mass Storage")
             .setSerial("FTDI001")
             .setUniqueID(2)
+            .setStandalone(false)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -267,6 +269,7 @@ public:
             .setName("Test FreeWili without FTDI - Mass Storage")
             .setSerial("HUB001") // Use Hub serial since no FTDI
             .setUniqueID(3)
+            .setStandalone(false)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -284,6 +287,7 @@ public:
             .setName("Test FreeWili without FTDI - Serials")
             .setSerial("HUB001") // Use Hub serial since no FTDI
             .setUniqueID(4)
+            .setStandalone(false)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }
@@ -299,6 +303,7 @@ public:
             .setName("Test Minimal FreeWili")
             .setSerial("FTDI001")
             .setUniqueID(5)
+            .setStandalone(false)
             .setUSBDevices(std::move(usbDevices))
             .build();
     }

--- a/test/test_hardware.cpp
+++ b/test/test_hardware.cpp
@@ -57,11 +57,11 @@ TEST(FwFinder, ExpectedHardware) {
             } else {
                 FAIL() << "Unexpected number of Mass Storage devices: " << massStorage.size();
             }
-        } else if (device.deviceType == Fw::DeviceType::DefCon2024Badge
-                   || device.deviceType == Fw::DeviceType::DefCon2025FwBadge
+        } else if (device.deviceType == Fw::DeviceType::DEFCON2024Badge
+                   || device.deviceType == Fw::DeviceType::DEFCON2025FwBadge
                    || device.deviceType == Fw::DeviceType::Winky)
         {
-            // Verify we found a DefCon badge device successfully.
+            // Verify we found a DEFCON badge device successfully.
             ASSERT_EQ(device.usbDevices.size(), 1) << "Expected exactly one USB device for badge";
             ASSERT_EQ(device.getUSBDevices(Fw::USBDeviceType::SerialMain).size(), 1)
                 << "Expected one USB SerialMain device for badge";
@@ -71,7 +71,7 @@ TEST(FwFinder, ExpectedHardware) {
                 << "Expected no USB SerialDisplay device for badge";
         } else if (device.deviceType == Fw::DeviceType::Unknown) {
             FAIL() << "Found device with unknown type: " << device.name
-                   << " - expected FreeWili or DefCon badge type";
+                   << " - expected FreeWili or DEFCON badge type";
         } else {
             // For other types, we can just log the type
             std::cout << "Found device of type: " << Fw::getDeviceTypeName(device.deviceType)


### PR DESCRIPTION
- Updated device strings:
    - "FreeWili" becomes "Free-WiLi"
    - "DefCon2024Badge" becomes "DEFCON 2024 Badge"
    - "DefCon2025Badge" becomes "DEFCON 2025 Badge"
- FreeWili Classic devices that have a corrupted driver of FTDI will no longer error out. They will be identified with serial "Unknown" instead.



C API:
- added fw_device_get_type_name()
- added fw_device_is_standalone()
- added fw_device_unique_id()
- added fw_usb_device_set()
- added fw_usb_device_get_type_name()
- fixed a segfault when mass storage wasn't mounted on linux
- fixed devices becoming invalid when unplugged and replugged or when device configuration changed
- Added more tests

C++ API:
- getUSBDevices() added overloads to accept better filtering
- added getMainUSBDevice()
- added getDisplayUSBDevice()
- added getFPGAUSBDevice()
- added getHubUSBDevice()
- added explict move and copy constructor for FreeWiliDevice
- added FreeWiliDevice::uniqueID
- added FreeWiliDevice::standalone
- added operator== to USBDevice
- added FreeWiliDeviceBuilder to simplify device creation internally

Python API:
- added standalone and uniqueID properties to FreeWiliDevice
- added FreeWiliDevice and USBDevice __eq__ operator
- added support for get_usb_devices() to handle C++ overloads for better filtering
- added get_main_usb_device()
- added get_display_usb_device()
- added get_fpga_usb_device()
- added get_hub_usb_device()
- added get_device_type_name()
- added get_usb_device_type_name()
